### PR TITLE
fix payload length exceeding the size limit

### DIFF
--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -32,7 +32,7 @@ class MessageListener(metaclass=ABCMeta):
         return self._listener_type == ListenerType.POINT_RESULT or self._listener_type == ListenerType.BOTH
 
     async def _output_stream(self):
-        async with websockets.connect(self._output_address) as websocket:
+        async with websockets.connect(self._output_address, max_size=None) as websocket:
             while self._is_running:
                 message = await websocket.recv() # Receive output messages from SENSR
                 
@@ -42,7 +42,7 @@ class MessageListener(metaclass=ABCMeta):
     
 
     async def _point_stream(self):
-        async with websockets.connect(self._point_address) as websocket:
+        async with websockets.connect(self._point_address, max_size=None) as websocket:
             while self._is_running:
                 message = await websocket.recv() # Receive output messages from SENSR
 


### PR DESCRIPTION
```bash
python3 console_output.py --address localhost --example_type point
Receiving SENSR output from ws://localhost...
Task exception was never retrieved
future: <Task finished name='Task-1' coro=<MessageListener._point_stream() done, defined at /home/seoulrobotics/sensr_sdk/python/sensr_message_listener.py:44> exception=ConnectionClosedError('code = 1006 (connection closed abnormally [internal]), no reason')>
Traceback (most recent call last):
  File "/home/seoulrobotics/anaconda3/lib/python3.8/site-packages/websockets/protocol.py", line 827, in transfer_data
    message = await self.read_message()
  File "/home/seoulrobotics/anaconda3/lib/python3.8/site-packages/websockets/protocol.py", line 895, in read_message
    frame = await self.read_data_frame(max_size=self.max_size)
  File "/home/seoulrobotics/anaconda3/lib/python3.8/site-packages/websockets/protocol.py", line 971, in read_data_frame
    frame = await self.read_frame(max_size)
  File "/home/seoulrobotics/anaconda3/lib/python3.8/site-packages/websockets/protocol.py", line 1047, in read_frame
    frame = await Frame.read(
  File "/home/seoulrobotics/anaconda3/lib/python3.8/site-packages/websockets/framing.py", line 126, in read
    raise PayloadTooBig(
websockets.exceptions.PayloadTooBig: payload length exceeds size limit (2187216 > 1048576 bytes)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/seoulrobotics/sensr_sdk/python/sensr_message_listener.py", line 47, in _point_stream
    message = await websocket.recv() # Receive output messages from SENSR
  File "/home/seoulrobotics/anaconda3/lib/python3.8/site-packages/websockets/protocol.py", line 509, in recv
    await self.ensure_open()
  File "/home/seoulrobotics/anaconda3/lib/python3.8/site-packages/websockets/protocol.py", line 812, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: code = 1006 (connection closed abnormally [internal]), no reason
```
solves this issue when printing large points