### PR TITLE
1006 connection closed problem fixed

### DIFF
--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -38,7 +38,7 @@ class MessageListener(metaclass=ABCMeta):
         return self._listener_type == ListenerType.POINT_RESULT or self._listener_type == ListenerType.BOTH
 
     async def _output_stream(self):
-        async with websockets.connect(self._output_address, ssl=self._ssl_context, max_size=None) as websocket:
+        async with websockets.connect(self._output_address, ssl=self._ssl_context, max_size=None, ping_interval=None) as websocket:
             while self._is_running:
                 message = await websocket.recv() # Receive output messages from SENSR
                 
@@ -48,7 +48,7 @@ class MessageListener(metaclass=ABCMeta):
     
 
     async def _point_stream(self):
-        async with websockets.connect(self._point_address, ssl=self._ssl_context, max_size=None) as websocket:
+        async with websockets.connect(self._point_address, ssl=self._ssl_context, max_size=None, ping_interval=None) as websocket:
             while self._is_running:
                 message = await websocket.recv() # Receive output messages from SENSR
 


### PR DESCRIPTION
When there are large sets of data python sdk sometimes fails to receive response abnormally shutting down the connection. adding this kw argument fixes the problem