### PR TITLE
Fix infinity loop issue if output publish level is '0'.

### DIFF
--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -76,8 +76,11 @@ class MessageListener(metaclass=ABCMeta):
 
     def connect(self):
         print('Receiving SENSR output from {}...'.format(self._address))
-        
-        self._loop = asyncio.get_event_loop()
+        try:
+            self._loop = asyncio.get_event_loop()
+        except asyncio.RuntimeError:
+            print('Fail to create event loop')
+            return False
         self._is_running = True
 
         if self.is_output_message_listening():
@@ -86,9 +89,8 @@ class MessageListener(metaclass=ABCMeta):
         if self.is_point_result_listening():
             self._loop.create_task(self._point_stream())
 
-        self._thread = Thread(target=self._loop.run_forever)
-        self._thread.start()
-        self._thread.join()
+        self._loop.run_forever()
+        return True
     
     def disconnect(self):
         self._is_running = False

--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -89,6 +89,7 @@ class MessageListener(metaclass=ABCMeta):
             self._loop.create_task(self._point_stream())
 
         self._loop.run_forever()
+        self._loop = None
         return True
     
     def disconnect(self):

--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -1,6 +1,5 @@
 import websockets
 import asyncio
-from threading import Thread
 from enum import Enum
 from abc import ABCMeta, abstractmethod # Abstract base classes
 


### PR DESCRIPTION
## Main fix
- Fix infinity loop if output publish level is '0'.
**Issue** : In case output publish level is '0', SENSR does not publish any point message. So `self._point_ws.closed` never be `True`.
**Solution** : Use `wait_for` for data receiving.
And removed unnecessary calm-down codes. 