### PR TITLE
AR-3573: Force protobuf version to be 3.12.0 from pip

### DIFF
--- a/python/configure.sh
+++ b/python/configure.sh
@@ -12,7 +12,7 @@ then
   echo protobuf-compiler is not found! It is being downloaded...
 
   PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-  PB_VER="3.11.4"
+  PB_VER="3.12.0"
   PB_ZIP="protoc-$PB_VER-linux-x86_64.zip"
   PROTOC_DIR="$SRC_DIR/protoc-$PB_VER"
   PROTOC="$PROTOC_DIR/bin/protoc"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-protobuf>=3.6
+protobuf==3.12.0
 websockets>=8.1


### PR DESCRIPTION
## Proposed changes
<!-- ADD SHORT SUMMARY HERE !!!!!!! -->
* Change configure script in python sdk to use protobuf 3.12.0 when protobuf is installed from pip

<!-- CHANGE THIS LINK !!!!!!! -->
[See on JIRA](https://seoulrobotics.atlassian.net/browse/AR-3573) 

## Types of changes
- [ ] New feature
- [ ] Update feature
- [ ] Bugfix
- [x] Refactoring
- [ ] Formatting changes
- [ ] Other <!-- PLEASE ADD A COMMENT TO EXPLAIN IT -->

## For reference
* **Please do a self-review before opening the PR!**
* Add at least 2 reviewers for non-trivial changes
* If you're not sure who to add as a reviewer refer to [this](https://seoulrobotics.atlassian.net/wiki/spaces/ARGOS/pages/1346699265/Branch+Strategy#Recommend-Reviewer)
* If you want to run unit test locally you can do `$cd build/[build-type]/_generated && ctest`
* Refer to the [Google C++ Style Code](https://google.github.io/styleguide/cppguide.html)
* Run clang-format on newly created files (`CTRL+SHIFT+I` in Vscode)
* **Don't mix formatting changes with other changes!**
* For large PRs refer to [this](https://seoulrobotics.atlassian.net/wiki/spaces/ARGOS/pages/1346699265/Branch+Strategy#How-to-handle-a-huge-Pull-request)