### PR TITLE
Add reconnecting when output buffer overflow happen

### DIFF
--- a/include/sensr_message_listener.h
+++ b/include/sensr_message_listener.h
@@ -17,6 +17,7 @@ namespace sensr {
         kNone,
         kOutputMessageConnection,
         kPointResultConnection,
+        kOutputBufferOverflow,
         kMax
     };
 

--- a/python/console_output.py
+++ b/python/console_output.py
@@ -13,8 +13,10 @@ class ZoneEvenListener(MessageListener):
     def __init__(self, address):
         super().__init__(address=address, 
                          listener_type=ListenerType.OUTPUT_MESSAGE)
+    
     def _on_error(self, message):
-        self.disconnect()    
+        self.reconnect()
+
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
 
@@ -32,6 +34,9 @@ class PointResultListener(MessageListener):
         super().__init__(address=address,
                          listener_type=ListenerType.POINT_RESULT)
     
+    def _on_error(self, message):
+        self.reconnect()
+
     def _on_get_point_result(self, message):
         assert isinstance(message, sensr_pcloud.PointResult), "message should be of type PointResult"
         
@@ -52,6 +57,9 @@ class ObjectListener(MessageListener):
     def __init__(self,address):
         super().__init__(address=address,
                          listener_type=ListenerType.OUTPUT_MESSAGE)
+
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -75,6 +83,9 @@ class HealthListener(MessageListener):
     def __init__(self,address):
         super().__init__(address=address,
                          listener_type=ListenerType.OUTPUT_MESSAGE)
+    
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -104,7 +115,6 @@ class TimeChecker(MessageListener):
         super().__init__(address=address,
                          listener_type=ListenerType.OUTPUT_MESSAGE)
     def _on_error(self, message):
-        print(message)
         self.reconnect()
 
     def _on_get_output_message(self, message):

--- a/python/console_output.py
+++ b/python/console_output.py
@@ -7,15 +7,14 @@ import google.protobuf.timestamp_pb2
 import ctypes
 import argparse
 import signal
-import sys
-
 
 class ZoneEvenListener(MessageListener):
 
     def __init__(self, address):
         super().__init__(address=address, 
                          listener_type=ListenerType.OUTPUT_MESSAGE)
-
+    def _on_error(self, message):
+        self.disconnect()    
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
 
@@ -104,6 +103,9 @@ class TimeChecker(MessageListener):
     def __init__(self,address):
         super().__init__(address=address,
                          listener_type=ListenerType.OUTPUT_MESSAGE)
+    def _on_error(self, message):
+        print(message)
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -150,3 +152,4 @@ if __name__ == "__main__":
     if current_listner is not None:
         signal.signal(signal.SIGINT, signal_handler)
         current_listner.connect()
+        current_listner = None

--- a/python/console_output.py
+++ b/python/console_output.py
@@ -162,4 +162,3 @@ if __name__ == "__main__":
     if current_listner is not None:
         signal.signal(signal.SIGINT, signal_handler)
         current_listner.connect()
-        current_listner = None

--- a/python/console_output_secure.py
+++ b/python/console_output_secure.py
@@ -20,6 +20,9 @@ class ZoneEvenListener(MessageListener):
                          use_ssl=True,
                          crt_file_path=cert_file_path)
 
+    def _on_error(self, message):
+        self.reconnect()
+
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
 
@@ -38,7 +41,10 @@ class PointResultListener(MessageListener):
                          listener_type=ListenerType.POINT_RESULT,
                          use_ssl=True,
                          crt_file_path=cert_file_path)
-    
+
+    def _on_error(self, message):
+        self.reconnect()
+
     def _on_get_point_result(self, message):
         assert isinstance(message, sensr_pcloud.PointResult), "message should be of type PointResult"
         
@@ -61,6 +67,9 @@ class ObjectListener(MessageListener):
                          listener_type=ListenerType.OUTPUT_MESSAGE,
                          use_ssl=True,
                          crt_file_path=cert_file_path)
+
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -86,6 +95,9 @@ class HealthListener(MessageListener):
                          listener_type=ListenerType.OUTPUT_MESSAGE,
                          use_ssl=True,
                          crt_file_path=cert_file_path)
+
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -116,6 +128,9 @@ class TimeChecker(MessageListener):
                          listener_type=ListenerType.OUTPUT_MESSAGE,
                          use_ssl=True,
                          crt_file_path=cert_file_path)
+
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"

--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -138,7 +138,6 @@ class MessageListener(metaclass=ABCMeta):
 
             self._loop.create_task(self._main())
             self._loop.run_forever()
-            self._loop = None
             return True
         return False
     

--- a/samples/console_output/main.cpp
+++ b/samples/console_output/main.cpp
@@ -10,7 +10,7 @@ class ZoneEventListener : public sensr::MessageListener {
 public:
   ZoneEventListener(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    std::cout << reason << std::endl;
+    std::cerr << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow ) {
@@ -36,7 +36,7 @@ class PointResultListener : public sensr::MessageListener {
 public:
   PointResultListener(sensr::Client* client) : MessageListener(ListeningType::kPointResult), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    std::cout << reason << std::endl;
+    std::cerr << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow ) {
@@ -62,7 +62,7 @@ class ObjectListener : public sensr::MessageListener {
 public:
   ObjectListener(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    std::cout << reason << std::endl;
+    std::cerr << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow) {
@@ -127,7 +127,7 @@ class HealthListener : public sensr::MessageListener {
 public:
   HealthListener(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    std::cout << reason << std::endl;
+    std::cerr << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow) {
@@ -156,7 +156,7 @@ class TimeChecker : public sensr::MessageListener {
 public:
   TimeChecker(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    std::cout << reason << std::endl;
+    std::cerr << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow) {
@@ -182,7 +182,7 @@ class ProfilingChecker : public sensr::MessageListener {
 public:
   ProfilingChecker(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    std::cout << reason << std::endl;
+    std::cerr << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow) {

--- a/samples/console_output/main.cpp
+++ b/samples/console_output/main.cpp
@@ -10,7 +10,7 @@ class ZoneEventListener : public sensr::MessageListener {
 public:
   ZoneEventListener(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    (void)reason;
+    std::cout << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow ) {
@@ -36,7 +36,7 @@ class PointResultListener : public sensr::MessageListener {
 public:
   PointResultListener(sensr::Client* client) : MessageListener(ListeningType::kPointResult), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    (void)reason;
+    std::cout << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow ) {
@@ -62,7 +62,7 @@ class ObjectListener : public sensr::MessageListener {
 public:
   ObjectListener(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    (void)reason;
+    std::cout << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow) {
@@ -127,11 +127,10 @@ class HealthListener : public sensr::MessageListener {
 public:
   HealthListener(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    (void)reason;
+    std::cout << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow) {
-      std::cout << "Reconnect" << std::endl;
       client_->Reconnect();
     }
   }
@@ -157,11 +156,10 @@ class TimeChecker : public sensr::MessageListener {
 public:
   TimeChecker(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    (void)reason;
+    std::cout << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow) {
-      std::cout << "Reconnect" << std::endl;
       client_->Reconnect();
     }
   }
@@ -184,7 +182,7 @@ class ProfilingChecker : public sensr::MessageListener {
 public:
   ProfilingChecker(sensr::Client* client) : MessageListener(ListeningType::kOutputMessage), client_(client) {}
   void OnError(Error error, const std::string& reason) override {
-    (void)reason;
+    std::cout << reason << std::endl;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
       error == sensr::MessageListener::Error::kPointResultConnection ||
       error == sensr::MessageListener::Error::kOutputBufferOverflow) {

--- a/samples/console_output/main.cpp
+++ b/samples/console_output/main.cpp
@@ -12,7 +12,8 @@ public:
   void OnError(Error error, const std::string& reason) override {
     (void)reason;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
-      error == sensr::MessageListener::Error::kPointResultConnection ) {
+      error == sensr::MessageListener::Error::kPointResultConnection ||
+      error == sensr::MessageListener::Error::kOutputBufferOverflow ) {
       client_->Reconnect();
     }
   }
@@ -37,7 +38,8 @@ public:
   void OnError(Error error, const std::string& reason) override {
     (void)reason;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
-      error == sensr::MessageListener::Error::kPointResultConnection ) {
+      error == sensr::MessageListener::Error::kPointResultConnection ||
+      error == sensr::MessageListener::Error::kOutputBufferOverflow ) {
       client_->Reconnect();
     }
   }
@@ -62,7 +64,8 @@ public:
   void OnError(Error error, const std::string& reason) override {
     (void)reason;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
-      error == sensr::MessageListener::Error::kPointResultConnection ) {
+      error == sensr::MessageListener::Error::kPointResultConnection ||
+      error == sensr::MessageListener::Error::kOutputBufferOverflow) {
       client_->Reconnect();
     }
   }
@@ -126,7 +129,9 @@ public:
   void OnError(Error error, const std::string& reason) override {
     (void)reason;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
-      error == sensr::MessageListener::Error::kPointResultConnection ) {
+      error == sensr::MessageListener::Error::kPointResultConnection ||
+      error == sensr::MessageListener::Error::kOutputBufferOverflow) {
+      std::cout << "Reconnect" << std::endl;
       client_->Reconnect();
     }
   }
@@ -154,7 +159,9 @@ public:
   void OnError(Error error, const std::string& reason) override {
     (void)reason;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
-      error == sensr::MessageListener::Error::kPointResultConnection ) {
+      error == sensr::MessageListener::Error::kPointResultConnection ||
+      error == sensr::MessageListener::Error::kOutputBufferOverflow) {
+      std::cout << "Reconnect" << std::endl;
       client_->Reconnect();
     }
   }
@@ -179,7 +186,8 @@ public:
   void OnError(Error error, const std::string& reason) override {
     (void)reason;
     if (error == sensr::MessageListener::Error::kOutputMessageConnection || 
-      error == sensr::MessageListener::Error::kPointResultConnection ) {
+      error == sensr::MessageListener::Error::kPointResultConnection ||
+      error == sensr::MessageListener::Error::kOutputBufferOverflow) {
       client_->Reconnect();
     }
   }

--- a/src/sensr_client.cpp
+++ b/src/sensr_client.cpp
@@ -101,10 +101,17 @@ namespace sensr
       std::cerr << "Wrong format" << std::endl;
       return;
     }
+    bool is_output_buffer_overflow = false;
+    if (output.has_event() && output.event().has_health() && 
+        output.event().health().master() == sensr_proto::SystemHealth_Status_OUTPUT_BUFFER_OVERFLOW) {
+      is_output_buffer_overflow = true;
+    }
     for (const auto& listener : listeners_) {
       if (listener->IsOutputMessageListening()) {
         listener->OnGetOutputMessage(output);
-        listener->OnGetOutpuMessage(output); //TODO: Remove this in next release.
+        if (is_output_buffer_overflow) {
+          listener->OnError(MessageListener::Error::kOutputBufferOverflow, message);
+        }  
       }
     }
   }

--- a/src/sensr_message_listener.cpp
+++ b/src/sensr_message_listener.cpp
@@ -11,7 +11,8 @@ namespace sensr {
     void MessageListener::OnError(MessageListener::Error error, const std::string& reason) {
         switch (error) {
             case Error::kOutputMessageConnection: 
-            case Error::kPointResultConnection: {
+            case Error::kPointResultConnection:
+            case Error::kOutputBufferOverflow: {
                 ERROR_LOG("Lost SENSR Connection fail(Reason: " + reason + "). Please reconnect."); 
                 break;
             }

--- a/src/websocket/websocket_endpoint_base.h
+++ b/src/websocket/websocket_endpoint_base.h
@@ -73,7 +73,7 @@ namespace sensr {
         auto close_code = connection->get_remote_close_code();
         std::string close_reason = connection->get_remote_close_reason();
         if (close_code == websocketpp::close::status::abnormal_close) {
-          OnFail("SENSR bened the connection because of no responding.");
+          OnFail("The connection to SENSR was banned because of no responding.");
         } else if (close_code == websocketpp::close::status::internal_endpoint_error && 
                    close_reason.find("Writing buffer is full") != std::string::npos) {
           OnFail(close_reason);

--- a/src/websocket/websocket_endpoint_base.h
+++ b/src/websocket/websocket_endpoint_base.h
@@ -69,8 +69,17 @@ namespace sensr {
       con->set_open_handler([this] (websocketpp::connection_hdl hdl) {
         status_ = Status::kOpen;
       });
-      con->set_close_handler([this] (websocketpp::connection_hdl hdl) {
-        status_ = Status::kClosed;
+      con->set_close_handler([this, connection = con] (websocketpp::connection_hdl hdl) {
+        auto close_code = connection->get_remote_close_code();
+        std::string close_reason = connection->get_remote_close_reason();
+        if (close_code == websocketpp::close::status::abnormal_close) {
+          OnFail("SENSR bened the connection because of no responding.");
+        } else if (close_code == websocketpp::close::status::internal_endpoint_error && 
+                   close_reason.find("Writing buffer is full") != std::string::npos) {
+          OnFail(close_reason);
+        } else {
+          status_ = Status::kClosed;          
+        } 
       });
     } catch(const std::exception& e) {
       std::string error_msg = "> Failed to connect SENSR.";


### PR DESCRIPTION
## Main changes
- Add `OUTPUT_BUFFER_OVERFLOW` error handling in cpp and python sdk.
  - When health in event message has `OUTPUT_BUFFER_OVERFLOW`, then drop the current connection and reconnect to the server.
  -  When current socket connection is closed unexpected, then reconnect to the server.