### PR TITLE
Fix "lambda capture in initializers only available with -std=c++14" warning.

### DIFF
--- a/src/websocket/websocket_endpoint_base.h
+++ b/src/websocket/websocket_endpoint_base.h
@@ -69,7 +69,8 @@ namespace sensr {
       con->set_open_handler([this] (websocketpp::connection_hdl hdl) {
         status_ = Status::kOpen;
       });
-      con->set_close_handler([this, connection = con] (websocketpp::connection_hdl hdl) {
+      const std::shared_ptr<websocketpp::connection<T>> connection  = con;
+      con->set_close_handler([this, connection] (websocketpp::connection_hdl hdl) {
         auto close_code = connection->get_remote_close_code();
         std::string close_reason = connection->get_remote_close_reason();
         if (close_code == websocketpp::close::status::abnormal_close) {


### PR DESCRIPTION
## Main changes
- Fix "lambda capture in initializers only available with -std=c++14" warning in cpp SDK.