### PR TITLE
Re-enable temporary disabled reconnect() functionality in python SDK.

### DIFF
--- a/python/console_output.py
+++ b/python/console_output.py
@@ -7,14 +7,15 @@ import google.protobuf.timestamp_pb2
 import ctypes
 import argparse
 import signal
-import sys
-
 
 class ZoneEvenListener(MessageListener):
 
     def __init__(self, address):
         super().__init__(address=address, 
                          listener_type=ListenerType.OUTPUT_MESSAGE)
+    
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -33,6 +34,9 @@ class PointResultListener(MessageListener):
         super().__init__(address=address,
                          listener_type=ListenerType.POINT_RESULT)
     
+    def _on_error(self, message):
+        self.reconnect()
+
     def _on_get_point_result(self, message):
         assert isinstance(message, sensr_pcloud.PointResult), "message should be of type PointResult"
         
@@ -53,6 +57,9 @@ class ObjectListener(MessageListener):
     def __init__(self,address):
         super().__init__(address=address,
                          listener_type=ListenerType.OUTPUT_MESSAGE)
+
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -76,6 +83,9 @@ class HealthListener(MessageListener):
     def __init__(self,address):
         super().__init__(address=address,
                          listener_type=ListenerType.OUTPUT_MESSAGE)
+    
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -104,6 +114,8 @@ class TimeChecker(MessageListener):
     def __init__(self,address):
         super().__init__(address=address,
                          listener_type=ListenerType.OUTPUT_MESSAGE)
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"

--- a/python/console_output_secure.py
+++ b/python/console_output_secure.py
@@ -20,6 +20,9 @@ class ZoneEvenListener(MessageListener):
                          use_ssl=True,
                          crt_file_path=cert_file_path)
 
+    def _on_error(self, message):
+        self.reconnect()
+
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
 
@@ -38,7 +41,10 @@ class PointResultListener(MessageListener):
                          listener_type=ListenerType.POINT_RESULT,
                          use_ssl=True,
                          crt_file_path=cert_file_path)
-    
+
+    def _on_error(self, message):
+        self.reconnect()
+
     def _on_get_point_result(self, message):
         assert isinstance(message, sensr_pcloud.PointResult), "message should be of type PointResult"
         
@@ -61,6 +67,9 @@ class ObjectListener(MessageListener):
                          listener_type=ListenerType.OUTPUT_MESSAGE,
                          use_ssl=True,
                          crt_file_path=cert_file_path)
+
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -86,6 +95,9 @@ class HealthListener(MessageListener):
                          listener_type=ListenerType.OUTPUT_MESSAGE,
                          use_ssl=True,
                          crt_file_path=cert_file_path)
+
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
@@ -116,6 +128,9 @@ class TimeChecker(MessageListener):
                          listener_type=ListenerType.OUTPUT_MESSAGE,
                          use_ssl=True,
                          crt_file_path=cert_file_path)
+
+    def _on_error(self, message):
+        self.reconnect()
 
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"

--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -5,7 +5,7 @@ import os
 from enum import Enum
 from abc import ABCMeta, abstractmethod # Abstract base classes
 
-from sensr_proto.output_pb2 import OutputMessage
+from sensr_proto.output_pb2 import OutputMessage, SystemHealth
 from sensr_proto.point_cloud_pb2 import PointResult
 
 class ListenerType(Enum):
@@ -14,7 +14,13 @@ class ListenerType(Enum):
     POINT_RESULT = 2
     BOTH = 3
 
+
 class MessageListener(metaclass=ABCMeta):
+    class State(Enum):
+        READY = 0
+        RUNNING = 1
+        STOP_REQUESTED = 2
+        STOPPED = 3
     
     @abstractmethod
     def __init__(self, 
@@ -39,6 +45,7 @@ class MessageListener(metaclass=ABCMeta):
         self._listener_type = listener_type
         self._output_ws = None
         self._point_ws = None
+        self._state = MessageListener.State.STOPPED
         
 
     def is_output_message_listening(self):
@@ -46,71 +53,105 @@ class MessageListener(metaclass=ABCMeta):
 
     def is_point_result_listening(self):
         return self._listener_type == ListenerType.POINT_RESULT or self._listener_type == ListenerType.BOTH
+    
+    def check_oveflow_error(self, output):
+        if output.HasField('event') and output.event.HasField('health'):
+            if output.event.health.master == SystemHealth.Status.OUTPUT_BUFFER_OVERFLOW:
+                return True
+        return False
 
     async def _output_stream(self):
-        async with websockets.connect(self._output_address, ssl=self._ssl_context, compression=None, max_size=None, ping_interval=None) as websocket:
-            self._output_ws = websocket
-            while self._is_running:
-                try:
-                    message = await asyncio.wait_for(websocket.recv(), timeout=1.0) # Receive output messages from SENSR                    
-                    output = OutputMessage()
-                    output.ParseFromString(message)
-                    self._on_get_output_message(output)
-                except asyncio.TimeoutError:
-                    pass
-            # Clean up websocket connection
-            await self._output_ws.close()
-            # if point websocket is already closed, then call loop.stop()
-            # loop.stop should be called to exit `loop.run_forever`
-            if ((self._point_ws == None) or 
-                (self._point_ws != None and self._point_ws.closed == True)):
-                if (self._loop != None and self._loop.is_running()):
-                    self._loop.stop()
+       while self._state != MessageListener.State.STOPPED and self._state != MessageListener.State.STOP_REQUESTED:
+            async with websockets.connect(self._output_address, ssl=self._ssl_context, compression=None, max_size=None, ping_interval=None) as websocket:
+                if self._output_ws != websocket:
+                    self._output_ws = websocket
+                while not self._output_ws.closed:
+                    try:
+                        message = await asyncio.wait_for(self._output_ws.recv(), timeout=1.0) # Receive output messages from SENSR                    
+                        output = OutputMessage()
+                        output.ParseFromString(message)
+                        if self.check_oveflow_error(output):
+                            self._on_error("Output Buffer Overflow.")
+                        self._on_get_output_message(output)
+                    except asyncio.TimeoutError:
+                        pass
+                    except websockets.ConnectionClosedOK:
+                        pass
+                    except websockets.ConnectionClosedError:
+                        self._on_error("Closed by error.")
 
     async def _point_stream(self):
-        async with websockets.connect(self._point_address, ssl=self._ssl_context, compression=None, max_size=None, ping_interval=None) as websocket:
-            self._point_ws = websocket
-            while self._is_running:
-                try:
-                    message = await asyncio.wait_for(websocket.recv(), timeout=1.0) # Receive output messages from SENSR
-                    points = PointResult()
-                    points.ParseFromString(message)
-                    self._on_get_point_result(points)
-                except asyncio.TimeoutError:
-                    pass
-            # Clean up websocket connection
+        while self._state != MessageListener.State.STOPPED and self._state != MessageListener.State.STOP_REQUESTED:
+            async with websockets.connect(self._point_address, ssl=self._ssl_context, compression=None, max_size=None, ping_interval=None) as websocket:
+                if self._point_ws != websocket:
+                    self._point_ws = websocket
+                while not self._point_ws.closed:
+                    try:
+                        message = await asyncio.wait_for(self._point_ws.recv(), timeout=1.0) # Receive output messages from SENSR
+                        points = PointResult()
+                        points.ParseFromString(message)
+                        self._on_get_point_result(points)
+                    except asyncio.TimeoutError:
+                        pass
+                    except websockets.ConnectionClosedOK:
+                        pass
+                    except websockets.ConnectionClosedError:
+                        self._on_error("Closed by error.")
+
+    async def _main(self):
+        while self._state != MessageListener.State.STOPPED:
+            if self._state == MessageListener.State.STOP_REQUESTED:
+                await self.close_connection()
+                self._state = MessageListener.State.STOPPED
+            elif self._state == MessageListener.State.READY:
+                await self.close_connection()
+                self._state = MessageListener.State.RUNNING
+            else:
+                await asyncio.sleep(0.1)
+        
+        # Finalize
+        self._loop.stop()
+
+    async def close_connection(self):
+        if self._output_ws != None and self.is_output_message_listening():
+            await self._output_ws.close()
+            self._output_ws = None
+        if self._point_ws != None and self.is_point_result_listening():
             await self._point_ws.close()
-            # if object websocket is already closed, then call loop.stop()
-            # loop.stop should be called to exit `loop.run_forever`
-            if ((self._output_ws == None) or 
-                (self._output_ws != None and self._output_ws.closed == True)):
-                if (self._loop != None and self._loop.is_running()):
-                    self._loop.stop()
+            self._point_ws = None
 
     def connect(self):
-        print('Receiving SENSR output from {}...'.format(self._address))
-        try:
-            self._loop = asyncio.get_event_loop()
-        except asyncio.RuntimeError:
-            print('Fail to create event loop')
-            return False
-        self._is_running = True
+        if self._state == MessageListener.State.STOPPED:
+            print('Receiving SENSR output from {}...'.format(self._address))
+            try:
+                self._loop = asyncio.get_event_loop()
+            except asyncio.RuntimeError:
+                print('Fail to create event loop')
+                return False
+            self._state = MessageListener.State.READY
 
-        if self.is_output_message_listening():
-            self._loop.create_task(self._output_stream())
+            if self.is_output_message_listening():
+                self._loop.create_task(self._output_stream())
 
-        if self.is_point_result_listening():
-            self._loop.create_task(self._point_stream())
+            if self.is_point_result_listening():
+                self._loop.create_task(self._point_stream())
 
-        self._loop.run_forever()
-        self._loop = None
-        return True
+            self._loop.create_task(self._main())
+            self._loop.run_forever()
+            return True
+        return False
     
     def disconnect(self):
-        self._is_running = False
+        self._state = MessageListener.State.STOP_REQUESTED
+    
+    def reconnect(self):
+        self._state = MessageListener.State.READY
 
     def _on_get_output_message(self, message):
         raise Exception('on_get_output_message() needs to be implemented in the derived class')
+    
+    def _on_error(self, message):
+        raise Exception('on_error() needs to be implemented in the derived class')
 
     def _on_get_point_result(self, message):
         raise Exception('on_get_point_result() needs to be implemented in the derived class')


### PR DESCRIPTION
## Main changes.
- Re-enable reconnect() functionality which was disabled in https://github.com/seoulrobotics/sensr_sdk/pull/53.
  Because ci test failure is fixed.