### PR TITLE
modify /python/console_output.py to ignore zero point object

### DIFF
--- a/python/console_output.py
+++ b/python/console_output.py
@@ -46,6 +46,10 @@ class PointResultListener(MessageListener):
             num_points = len(point_cloud.points) // (float_size * 3) # Each point is 3 floats (x,y,z)
             
             intensity_np = np.frombuffer(point_cloud.intensities, np.float32)
+            
+            if len(intensity_np) == 0:
+                continue    
+            
             min_intensity = np.min(intensity_np)
             median_intensity = np.median(intensity_np)
             max_intensity = np.max(intensity_np)
@@ -79,10 +83,15 @@ class ObjectListener(MessageListener):
                 object_point_num = len(obj.points) // (float_size * 3) # Each point is 3 floats (x,y,z)
 
                 intensity_np = np.frombuffer(obj.intensities, np.float32)
+                
+                if len(intensity_np) == 0:
+                    print('continue')
+                    continue
+                
                 min_intensity = np.min(intensity_np)
                 median_intensity = np.median(intensity_np)
                 max_intensity = np.max(intensity_np)
-                
+
                 print('Obj ({0}): point no. {1}'.format(obj.id, object_point_num))
                 print('Obj ({0}): point intensity [min, median, max] is [{1}, {2}, {3}]'.format(obj.id, min_intensity, median_intensity, max_intensity))
                 print('Obj ({0}): velocity {1}'.format(obj.id, obj.velocity))

--- a/python/console_output.py
+++ b/python/console_output.py
@@ -85,7 +85,6 @@ class ObjectListener(MessageListener):
                 intensity_np = np.frombuffer(obj.intensities, np.float32)
                 
                 if len(intensity_np) == 0:
-                    print('continue')
                     continue
                 
                 min_intensity = np.min(intensity_np)

--- a/python/console_output.py
+++ b/python/console_output.py
@@ -47,12 +47,14 @@ class PointResultListener(MessageListener):
             
             intensity_np = np.frombuffer(point_cloud.intensities, np.float32)
             
-            if len(intensity_np) == 0:
-                continue    
-            
-            min_intensity = np.min(intensity_np)
-            median_intensity = np.median(intensity_np)
-            max_intensity = np.max(intensity_np)
+            if len(intensity_np) != 0:
+                min_intensity = np.min(intensity_np)
+                median_intensity = np.median(intensity_np)
+                max_intensity = np.max(intensity_np)
+            else:
+                min_intensity = 0.0
+                median_intensity = 0.0
+                max_intensity = 0.0
 
             if point_cloud.type == sensr_pcloud.PointResult.PointCloud.Type.RAW:
                 print('Topic ({0}) no. of points - {1}. Min and max intensity is [{2}, {3}]'.format(point_cloud.id, num_points, min_intensity, max_intensity))
@@ -84,12 +86,14 @@ class ObjectListener(MessageListener):
 
                 intensity_np = np.frombuffer(obj.intensities, np.float32)
                 
-                if len(intensity_np) == 0:
-                    continue
-                
-                min_intensity = np.min(intensity_np)
-                median_intensity = np.median(intensity_np)
-                max_intensity = np.max(intensity_np)
+                if len(intensity_np) != 0:
+                    min_intensity = np.min(intensity_np)
+                    median_intensity = np.median(intensity_np)
+                    max_intensity = np.max(intensity_np)
+                else:
+                    min_intensity = 0.0
+                    median_intensity = 0.0
+                    max_intensity = 0.0
 
                 print('Obj ({0}): point no. {1}'.format(obj.id, object_point_num))
                 print('Obj ({0}): point intensity [min, median, max] is [{1}, {2}, {3}]'.format(obj.id, min_intensity, median_intensity, max_intensity))


### PR DESCRIPTION
SDK crashes in the process of calculating intensity_np
When receiving object information without a point, the above problem occurs.
Object information without a point was judged to be unnecessary, so I modified the SDK to ignore the information.