### PR TITLE
Split authentication way

### DIFF
--- a/python/console_output_secure.py
+++ b/python/console_output_secure.py
@@ -84,13 +84,14 @@ class ObjectListener(MessageListener):
             for obj in message.stream.objects:
                 float_size = ctypes.sizeof(ctypes.c_float)
                 object_point_num = len(obj.points) // (float_size * 3) # Each point is 3 floats (x,y,z)
-
+                
                 print('Obj ({0}): point no. {1}'.format(obj.id, object_point_num))
                 print('Obj ({0}): velocity {1}'.format(obj.id, obj.velocity))
                 print('Obj ({0}): bbox {1}'.format(obj.id, obj.bbox))
                 print('Obj ({0}): tracking status {1}'.format(obj.id, sensr_type.TrackingStatus.Name(int(obj.tracking_status))))
                 print('Obj ({0}): Object type {1}'.format(obj.id, sensr_type.LabelType.Name(int(obj.label))))
                 print('Obj ({0}): prediction {1}'.format(obj.id, obj.prediction))
+
 
 
 class HealthListener(MessageListener):

--- a/python/console_output_secure.py
+++ b/python/console_output_secure.py
@@ -80,7 +80,7 @@ class ObjectListener(MessageListener):
     def _on_get_output_message(self, message):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
 
-        if message.HasField('stream'):
+        if message.HasField('stream') and message.stream.has_objects:
             for obj in message.stream.objects:
                 float_size = ctypes.sizeof(ctypes.c_float)
                 object_point_num = len(obj.points) // (float_size * 3) # Each point is 3 floats (x,y,z)

--- a/python/console_output_secure.py
+++ b/python/console_output_secure.py
@@ -51,7 +51,7 @@ class PointResultListener(MessageListener):
 
     def _on_get_point_result(self, message):
         assert isinstance(message, sensr_pcloud.PointResult), "message should be of type PointResult"
-
+        
         for point_cloud in message.points:
             float_size = ctypes.sizeof(ctypes.c_float)
             num_points = len(point_cloud.points) // (float_size * 3) # Each point is 3 floats (x,y,z)
@@ -84,6 +84,7 @@ class ObjectListener(MessageListener):
             for obj in message.stream.objects:
                 float_size = ctypes.sizeof(ctypes.c_float)
                 object_point_num = len(obj.points) // (float_size * 3) # Each point is 3 floats (x,y,z)
+
                 print('Obj ({0}): point no. {1}'.format(obj.id, object_point_num))
                 print('Obj ({0}): velocity {1}'.format(obj.id, obj.velocity))
                 print('Obj ({0}): bbox {1}'.format(obj.id, obj.bbox))
@@ -109,7 +110,7 @@ class HealthListener(MessageListener):
         assert isinstance(message, sensr_output.OutputMessage), "message should be of type OutputMessage"
 
         if message.HasField('stream') and message.stream.HasField('health'):
-
+            
             system_health = message.stream.health
             print('System health: {0}'.format(system_health.master))
 
@@ -166,7 +167,7 @@ def signal_handler(sig, frame):
         current_listner.disconnect()
 
 if __name__ == "__main__":
-
+    
     args = parse_arguments()
 
     address = args.address

--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -22,7 +22,7 @@ class MessageListener(metaclass=ABCMeta):
         RUNNING = 1
         STOP_REQUESTED = 2
         STOPPED = 3
-
+    
     @abstractmethod
     def __init__(self, 
                  address="localhost", 
@@ -61,7 +61,7 @@ class MessageListener(metaclass=ABCMeta):
         self._output_ws = None
         self._point_ws = None
         self._state = MessageListener.State.STOPPED
-
+        
 
     def is_output_message_listening(self):
         return self._listener_type == ListenerType.OUTPUT_MESSAGE or self._listener_type == ListenerType.BOTH
@@ -170,5 +170,3 @@ class MessageListener(metaclass=ABCMeta):
 
     def _on_get_point_result(self, message):
         raise Exception('on_get_point_result() needs to be implemented in the derived class')
-
-        

--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -3,7 +3,7 @@ import asyncio
 import ssl
 import os
 from enum import Enum
-from abc import ABCMeta, abstractmethod  # Abstract base classes
+from abc import ABCMeta, abstractmethod # Abstract base classes
 import certifi
 
 from sensr_proto.output_pb2 import OutputMessage, SystemHealth


### PR DESCRIPTION
### introduction

- From what I understand, currently, when using the `wss` protocol in `console_ouput_secure.py` it uses a self-signed certificate.
- However, that method is unsecured security. So, thhe web server does not accept self-signed certificates.
- Result
  -  I edited the code to use the certificate that the OS has when using the `wss` protocol.

---

### Edited content
`sensr_message_listener.py`

-  Case 1: Enter an address starting with `wss` or `https`
    - Check if the OS has the certificate. 
        - If the user has an OS certificate, it will be used. Otherwise, a self-signed certificate will be used.
    - But if the OS doesn't have the certificate, I think quitting the SDK is better. 
        -  It would be nice if you could leave that part as a comment.
    - test command
          `python3 console_output_secure.py --address https://sample-company-gpu.demo.seoulrobotics.io --example_type object`
          `python3 console_output_secure.py --address wss://sample-company-gpu.demo.seoulrobotics.io --example_type object`
-  Case 2: Enter an address starting with `ws`
    -  In this case, the SSL certificate is not need. So,`None` value was put in `ssl_context`.
- Case 3: Etc
    - If the user enters an address that starts with `http`, change `http` to `ws`.
    - In other cases (enter the IP address), code added the `ws` protocol to the address.
    - test command (base on localhost)
        `python3 console_output.py --example_type point`

`console_output_secure.py`
- Made it possible for the user to enter the `output port` and `point port` on the command line.