### PR TITLE
Refactor sensr::Client and revert asio for Client::Reconnect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,12 @@ endif()
 
 add_definitions(-DASIO_STANDALONE)
 
-set(SOURCE_FILES 
-    src/sensr_client.cpp 
-    src/sensr_message_listener.cpp 
-    src/websocket/websocket_endpoint_base.cpp 
-    src/websocket/websocket_endpoint.cpp 
+set(SOURCE_FILES
+    src/sensr_client.cpp
+    src/sensr_message_listener.cpp
+    src/message_broker.cpp
+    src/websocket/websocket_endpoint_base.cpp
+    src/websocket/websocket_endpoint.cpp
     src/websocket/websocket_secure_endpoint.cpp)
 add_library(sensr_sdk SHARED ${generated_code} ${generated_header_code} ${SOURCE_FILES})
 
@@ -37,7 +38,7 @@ target_compile_options(sensr_sdk PRIVATE -Wno-attributes -Wno-deprecated -Wno-co
 ####### Compiler Flags ###########
 
 target_include_directories(sensr_sdk
-    PUBLIC 
+    PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/websocketpp>
@@ -67,7 +68,7 @@ file(GLOB_RECURSE header_files
 
 add_subdirectory(proto)
 
-set_target_properties(sensr_sdk PROPERTIES PUBLIC_HEADER "${header_files}")  
+set_target_properties(sensr_sdk PROPERTIES PUBLIC_HEADER "${header_files}")
 
 write_basic_package_version_file(
     "${version_config}" COMPATIBILITY SameMajorVersion

--- a/include/sensr_client.h
+++ b/include/sensr_client.h
@@ -23,6 +23,9 @@ namespace sensr
     void UnsubscribeMessageListener(const std::shared_ptr<MessageListener>& listener);
 
   private:
+    void ClearListeners();
+
+  private:
     std::unique_ptr<WebSocketEndPointBase> output_endpoint_;
     std::unique_ptr<WebSocketEndPointBase> point_endpoint_;
     std::vector<std::shared_ptr<MessageListener>> listeners_;

--- a/include/sensr_client.h
+++ b/include/sensr_client.h
@@ -11,7 +11,8 @@
 
 namespace sensr {
 class MessageListener;
-class WebSocketEndPointBase;
+class MessageBrokerBase;
+
 class Client {
  public:
   Client(const std::string& address, const std::string& cert_path = "");
@@ -24,20 +25,12 @@ class Client {
   void ClearListeners();
 
  private:
-  std::unique_ptr<WebSocketEndPointBase> output_endpoint_;
-  std::unique_ptr<WebSocketEndPointBase> point_endpoint_;
-  std::vector<std::shared_ptr<MessageListener>> listeners_;
+  enum struct MessageType : uint32_t { Output = 0u, Points, Max };
+  std::array<std::unique_ptr<MessageBrokerBase>, static_cast<uint32_t>(MessageType::Max)> message_brokers_;
 
   std::atomic<bool> is_reconnecting_;
   std::thread reconnection_thread_;
   asio::io_context io_context_;
   void reconnection_async();
-
-  void OnResultMessage(const std::string& msg);
-  void OnPointMessage(const std::string& msg);
-  void OnResultError(const std::string& err);
-  void OnPointError(const std::string& err);
-  bool IsResultListening() const;
-  bool IsPointListening() const;
 };
 }  // namespace sensr

--- a/include/sensr_client.h
+++ b/include/sensr_client.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <asio.hpp>
 #include <atomic>
 #include <memory>
 #include <string>
@@ -25,12 +24,10 @@ class Client {
   void ClearListeners();
 
  private:
-  enum struct MessageType : uint32_t { Output = 0u, Points, Max };
-  std::array<std::unique_ptr<MessageBrokerBase>, static_cast<uint32_t>(MessageType::Max)> message_brokers_;
+  enum struct MessageType : uint32_t { Output = 0u, Points };
+  std::array<std::unique_ptr<MessageBrokerBase>, 2u> message_brokers_;
 
-  std::atomic<bool> is_reconnecting_;
+  std::atomic<bool> is_reconnecting_ = false;
   std::thread reconnection_thread_;
-  asio::io_context io_context_;
-  void reconnection_async();
 };
 }  // namespace sensr

--- a/include/sensr_client.h
+++ b/include/sensr_client.h
@@ -1,48 +1,43 @@
 #pragma once
 
+#include <asio.hpp>
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+
 #include "sensr_proto/output.pb.h"
 #include "sensr_proto/point_cloud.pb.h"
-#include <string>
-#include <memory>
-#include <functional>
-#include <atomic>
-#include <thread>
-#include <asio.hpp>
 
-namespace sensr
-{
-  class MessageListener;
-  class WebSocketEndPointBase;
-  class Client
-  {
-  public:
-    Client(const std::string &address, const std::string& cert_path = "");
-    ~Client();
-    void Reconnect(); // Call when Error occur
-    bool SubscribeMessageListener(const std::shared_ptr<MessageListener>& listener);
-    void UnsubscribeMessageListener(const std::shared_ptr<MessageListener>& listener);
+namespace sensr {
+class MessageListener;
+class WebSocketEndPointBase;
+class Client {
+ public:
+  Client(const std::string& address, const std::string& cert_path = "");
+  ~Client();
+  void Reconnect();  // Call when Error occur
+  bool SubscribeMessageListener(const std::shared_ptr<MessageListener>& listener);
+  void UnsubscribeMessageListener(const std::shared_ptr<MessageListener>& listener);
 
-  private:
-    void ClearListeners();
+ private:
+  void ClearListeners();
 
-  private:
-    std::unique_ptr<WebSocketEndPointBase> output_endpoint_;
-    std::unique_ptr<WebSocketEndPointBase> point_endpoint_;
-    std::vector<std::shared_ptr<MessageListener>> listeners_;
-    const std::string address_;
-    bool use_ssl_;
+ private:
+  std::unique_ptr<WebSocketEndPointBase> output_endpoint_;
+  std::unique_ptr<WebSocketEndPointBase> point_endpoint_;
+  std::vector<std::shared_ptr<MessageListener>> listeners_;
 
-    std::atomic<bool> is_reconnecting_;
-    std::thread reconnection_thread_;
-    asio::io_context io_context_;
-    void reconnection_async();
+  std::atomic<bool> is_reconnecting_;
+  std::thread reconnection_thread_;
+  asio::io_context io_context_;
+  void reconnection_async();
 
-    void OnResultMessage(const std::string &msg);
-    void OnPointMessage(const std::string &msg);
-    void OnResultError(const std::string &err);
-    void OnPointError(const std::string &err);
-    bool IsResultListening() const;
-    bool IsPointListening() const;
-    std::string GetProtocol() const { return use_ssl_ ? "wss" : "ws"; }
-  };
-} // namespace sensr
+  void OnResultMessage(const std::string& msg);
+  void OnPointMessage(const std::string& msg);
+  void OnResultError(const std::string& err);
+  void OnPointError(const std::string& err);
+  bool IsResultListening() const;
+  bool IsPointListening() const;
+};
+}  // namespace sensr

--- a/include/sensr_message_listener.h
+++ b/include/sensr_message_listener.h
@@ -24,7 +24,7 @@ namespace sensr {
     MessageListener(ListeningType listening_type = ListeningType::kOutputMessage);
     virtual ~MessageListener() = default;
     virtual void OnError(Error error, const std::string& reason);
-    virtual void OnGetOutpuMessage(const sensr_proto::OutputMessage &message); // Deprecated!!!!
+    [[deprecated]] virtual void OnGetOutpuMessage(const sensr_proto::OutputMessage &message); // Deprecated!!!!
     virtual void OnGetOutputMessage(const sensr_proto::OutputMessage &message);
     virtual void OnGetPointResult(const sensr_proto::PointResult &message);
     bool IsOutputMessageListening() const;

--- a/src/message_broker.cpp
+++ b/src/message_broker.cpp
@@ -1,0 +1,123 @@
+#include "message_broker.h"
+
+#include "websocket/websocket_endpoint.h"
+#include "websocket/websocket_secure_endpoint.h"
+
+namespace sensr {
+
+MessageBrokerBase::MessageBrokerBase(const std::string& address,
+                                     uint16_t port,
+                                     const std::string& cert_path) {
+  if (cert_path.empty()) {
+    endpoint_ = std::make_unique<WebSocketEndPoint>(address, port);
+  } else {
+    endpoint_ = std::make_unique<WebSocketSecureEndPoint>(address, port, cert_path);
+  }
+}
+
+bool MessageBrokerBase::IsConnected() const { return endpoint_->IsConnected(); }
+
+bool MessageBrokerBase::IsListening() const { return !listeners_.empty(); }
+
+void MessageBrokerBase::TryAttachListener(const std::shared_ptr<MessageListener>& listener) {
+  bool start_connection = listeners_.empty();
+
+  if (listener != nullptr && IsAttachable(*listener)) {
+    if (auto it = std::find(listeners_.cbegin(), listeners_.cend(), listener);
+        it == listeners_.cend()) {
+      listeners_.push_back(listener);
+    }
+  }
+
+  if (start_connection && !listeners_.empty()) {
+    endpoint_->Connect();
+  }
+}
+
+void MessageBrokerBase::TryDetachListener(const std::shared_ptr<MessageListener>& listener) {
+  bool end_connection = !listeners_.empty();
+
+  if (listener != nullptr && IsAttachable(*listener)) {
+    if (auto it = std::find(listeners_.cbegin(), listeners_.cend(), listener);
+        it != listeners_.cend()) {
+      listeners_.erase(it);
+    }
+  }
+
+  if (end_connection && listeners_.empty()) {
+    endpoint_->Close(websocketpp::close::status::normal);
+  }
+}
+
+void MessageBrokerBase::ClearListeners() {
+  listeners_.clear();
+  endpoint_->Close(websocketpp::close::status::normal);
+}
+
+OutputMessageBroker::OutputMessageBroker(const std::string& address,
+                                         uint16_t port,
+                                         const std::string& cert_path)
+    : MessageBrokerBase(address, port, cert_path) {
+  endpoint_->SetCallbacks([this](auto&& msg) { OnMessage(msg); },
+                          [this](auto&& err) { OnError(err); });
+}
+
+bool OutputMessageBroker::IsAttachable(const MessageListener& listener) const {
+  return listener.IsOutputMessageListening();
+}
+
+void OutputMessageBroker::OnMessage(const std::string& message) {
+  sensr_proto::OutputMessage output;
+  if (!output.ParseFromString(message)) {
+    std::cerr << "Wrong format" << std::endl;
+    return;
+  }
+
+  bool is_output_buffer_overflow = false;
+  if (output.has_event() && output.event().has_health() &&
+      output.event().health().master() == sensr_proto::SystemHealth_Status_OUTPUT_BUFFER_OVERFLOW) {
+    is_output_buffer_overflow = true;
+  }
+  for (const auto& listener : listeners_) {
+    listener->OnGetOutputMessage(output);
+    if (is_output_buffer_overflow) {
+      listener->OnError(MessageListener::Error::kOutputBufferOverflow, message);
+    }
+  }
+}
+
+void OutputMessageBroker::OnError(const std::string& error) {
+  for (const auto& listener : listeners_) {
+    listener->OnError(MessageListener::Error::kOutputMessageConnection, error);
+  }
+}
+
+PointMessageBroker::PointMessageBroker(const std::string& address,
+                                       uint16_t port,
+                                       const std::string& cert_path)
+    : MessageBrokerBase(address, port, cert_path) {
+  endpoint_->SetCallbacks([this](auto&& msg) { OnMessage(msg); },
+                          [this](auto&& err) { OnError(err); });
+}
+
+bool PointMessageBroker::IsAttachable(const MessageListener& listener) const {
+  return listener.IsPointResultListening();
+}
+
+void PointMessageBroker::OnMessage(const std::string& message) {
+  sensr_proto::PointResult output;
+  if (!output.ParseFromString(message)) {
+    std::cerr << "Wrong format" << std::endl;
+    return;
+  }
+  for (const auto& listener : listeners_) {
+    listener->OnGetPointResult(output);
+  }
+}
+
+void PointMessageBroker::OnError(const std::string& error) {
+  for (const auto& listener : listeners_) {
+    listener->OnError(MessageListener::Error::kPointResultConnection, error);
+  }
+}
+}  // namespace sensr

--- a/src/message_broker.cpp
+++ b/src/message_broker.cpp
@@ -19,6 +19,19 @@ bool MessageBrokerBase::IsConnected() const { return endpoint_->IsConnected(); }
 
 bool MessageBrokerBase::IsListening() const { return !listeners_.empty(); }
 
+void MessageBrokerBase::Reconnect() {
+  if (listeners_.empty()) {
+    return;
+  }
+
+  endpoint_->Close(websocketpp::close::status::normal);
+
+  using namespace std::chrono_literals;
+  std::this_thread::sleep_for(1ms);
+
+  endpoint_->Connect();
+}
+
 void MessageBrokerBase::TryAttachListener(const std::shared_ptr<MessageListener>& listener) {
   bool start_connection = listeners_.empty();
 

--- a/src/message_broker.h
+++ b/src/message_broker.h
@@ -16,6 +16,8 @@ class MessageBrokerBase {
   bool IsConnected() const;
   bool IsListening() const;
 
+  void Reconnect();
+
   void TryAttachListener(const std::shared_ptr<MessageListener>& listener);
   void TryDetachListener(const std::shared_ptr<MessageListener>& listener);
 

--- a/src/message_broker.h
+++ b/src/message_broker.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <string>
+
+#include "sensr_message_listener.h"
+#include "websocket/websocket_endpoint_base.h"
+
+namespace sensr {
+class MessageBrokerBase {
+ public:
+  MessageBrokerBase(const std::string& address,
+                    uint16_t port,
+                    const std::string& cert_path = std::string());
+  virtual ~MessageBrokerBase() = default;
+
+  bool IsConnected() const;
+  bool IsListening() const;
+
+  void TryAttachListener(const std::shared_ptr<MessageListener>& listener);
+  void TryDetachListener(const std::shared_ptr<MessageListener>& listener);
+
+  void ClearListeners();
+
+ private:
+  virtual bool IsAttachable(const MessageListener& listener) const = 0;
+
+ protected:
+  std::unique_ptr<WebSocketEndPointBase> endpoint_;
+
+  std::vector<std::shared_ptr<MessageListener>> listeners_;
+};
+
+class OutputMessageBroker : public MessageBrokerBase {
+ public:
+  OutputMessageBroker(const std::string& address,
+                      uint16_t port,
+                      const std::string& cert_path = std::string());
+
+ private:
+  bool IsAttachable(const MessageListener& listener) const override;
+
+  void OnMessage(const std::string& message);
+  void OnError(const std::string& error);
+};
+
+class PointMessageBroker : public MessageBrokerBase {
+ public:
+  PointMessageBroker(const std::string& address,
+                     uint16_t port,
+                     const std::string& cert_path = std::string());
+
+ private:
+  bool IsAttachable(const MessageListener& listener) const override;
+
+  void OnMessage(const std::string& message);
+  void OnError(const std::string& error);
+};
+}  // namespace sensr

--- a/src/sensr_client.cpp
+++ b/src/sensr_client.cpp
@@ -42,8 +42,7 @@ void Client::Reconnect() {
   reconnection_thread_ = std::thread([this] {
     size_t reconnection_counter = 0u;
     while (is_reconnecting_) {
-      std::cout << "Reconnecting... " << ++reconnection_counter << "-th trial" << std::endl;
-      INFO_LOG("Reconnecting...");
+      INFO_LOG("Reconnecting... TryCount: "s + std::to_string(++reconnection_counter));
 
       for (const auto& broker : message_brokers_) {
         broker->Reconnect();

--- a/src/sensr_client.cpp
+++ b/src/sensr_client.cpp
@@ -7,189 +7,195 @@
 #include "websocket/websocket_secure_endpoint.h"
 
 namespace sensr {
-  Client::Client(const std::string& address, const std::string& cert_path)
-      : address_(address), use_ssl_(!cert_path.empty()), is_reconnecting_(false) {
-    if (use_ssl_) {
-      output_endpoint_ = std::make_unique<WebSocketSecureEndPoint>(cert_path);
-      point_endpoint_ = std::make_unique<WebSocketSecureEndPoint>(cert_path);
-    } else {
-      output_endpoint_ = std::make_unique<WebSocketEndPoint>();
-      point_endpoint_ = std::make_unique<WebSocketEndPoint>();
-    }
+Client::Client(const std::string& address, const std::string& cert_path)
+    : is_reconnecting_(false) {
+  const uint16_t kOutputPort = 5050u;
+  const uint16_t kPointPort = 5051u;
+
+  // FIXME: this sucks
+  auto output_msg_cb = [this](auto&& msg) { OnResultMessage(msg); };
+  auto output_err_cb = [this](auto&& err) { OnResultError(err); };
+
+  auto point_msg_cb = [this](auto&& msg) { OnPointMessage(msg); };
+  auto point_err_cb = [this](auto&& err) { OnPointError(err); };
+
+  if (cert_path.empty()) {
+    output_endpoint_ =
+        std::make_unique<WebSocketEndPoint>(address, kOutputPort, output_msg_cb, output_err_cb);
+    point_endpoint_ =
+        std::make_unique<WebSocketEndPoint>(address, kPointPort, point_msg_cb, point_err_cb);
+  } else {
+    output_endpoint_ = std::make_unique<WebSocketSecureEndPoint>(
+        address, kOutputPort, output_msg_cb, output_err_cb, cert_path);
+    point_endpoint_ = std::make_unique<WebSocketSecureEndPoint>(
+        address, kPointPort, point_msg_cb, point_err_cb, cert_path);
   }
+}
 
-  Client::~Client() {
-    ClearListeners();
+Client::~Client() {
+  ClearListeners();
 
-    io_context_.stop();
+  io_context_.stop();
+  if (reconnection_thread_.joinable()) {
+    reconnection_thread_.join();
+  }
+}
+
+void Client::Reconnect() {
+  if (!is_reconnecting_) {
     if (reconnection_thread_.joinable()) {
       reconnection_thread_.join();
     }
+
+    is_reconnecting_ = true;
+    io_context_.restart();
+
+    asio::post(io_context_, [this]() { reconnection_async(); });
+    reconnection_thread_ = std::thread([this] { io_context_.run(); });
   }
+}
 
-  void Client::Reconnect() {
-    if (!is_reconnecting_) {
-      if (reconnection_thread_.joinable()) {
-        reconnection_thread_.join();
-      }
+void Client::reconnection_async() {
+  INFO_LOG("Reconnecting...");
+  auto temp = listeners_;
 
-      is_reconnecting_ = true;
-      io_context_.restart();
+  ClearListeners();
 
-      asio::post(io_context_, [this]() { reconnection_async(); });
-      reconnection_thread_ = std::thread([this] {
-        io_context_.run();
-      });
-    }
+  for (const auto& listener : temp) {
+    SubscribeMessageListener(listener);
   }
+  const bool is_output_connected = !IsResultListening() || output_endpoint_->IsConnected();
+  const bool is_point_connected = !IsPointListening() || point_endpoint_->IsConnected();
 
-  void Client::reconnection_async() {
-    INFO_LOG("Reconnecting...");
-    auto temp = listeners_;
-
-    ClearListeners();
-
-    for (const auto& listener : temp) {
-      SubscribeMessageListener(listener);
-    }
-    const bool is_output_connected = !IsResultListening() || output_endpoint_->IsConnected();
-    const bool is_point_connected = !IsPointListening() || point_endpoint_->IsConnected();
-
-    if (is_output_connected && is_point_connected) {
-      INFO_LOG("Reconnected!");
-      is_reconnecting_ = false;
-    } else {
-      asio::steady_timer sleep_timer(io_context_, asio::chrono::seconds(1));
-      sleep_timer.wait();
-      reconnection_async();
-    }
+  if (is_output_connected && is_point_connected) {
+    INFO_LOG("Reconnected!");
+    is_reconnecting_ = false;
+  } else {
+    asio::steady_timer sleep_timer(io_context_, asio::chrono::seconds(1));
+    sleep_timer.wait();
+    reconnection_async();
   }
+}
 
-  bool Client::SubscribeMessageListener(const std::shared_ptr<MessageListener>& listener) {
-    bool ret = false;
-    // Connect to SENSR
-    if (std::find(listeners_.begin(), listeners_.end(), listener) == listeners_.end()) {
-      // OutputMessage Port
-      if (listener->IsOutputMessageListening()) {
-        if (!IsResultListening()) {
-          ret = output_endpoint_->Connect(
-              GetProtocol() + "://" + address_ + ":5050",
-              std::bind(&Client::OnResultMessage, this, std::placeholders::_1),
-              std::bind(&Client::OnResultError, this, std::placeholders::_1));
-        } else {
-          ret = true;
-        }
-      }
-      // PointResult Port
-      if (listener->IsPointResultListening()) {
-        if (!IsPointListening()) {
-          ret = point_endpoint_->Connect(
-              GetProtocol() + "://" + address_ + ":5051",
-              std::bind(&Client::OnPointMessage, this, std::placeholders::_1),
-              std::bind(&Client::OnPointError, this, std::placeholders::_1));
-        } else {
-          ret = true;
-        }
+bool Client::SubscribeMessageListener(const std::shared_ptr<MessageListener>& listener) {
+  bool ret = false;
+  // Connect to SENSR
+  if (std::find(listeners_.begin(), listeners_.end(), listener) == listeners_.end()) {
+    // OutputMessage Port
+    if (listener->IsOutputMessageListening()) {
+      if (!IsResultListening()) {
+        ret = output_endpoint_->Connect();
+      } else {
+        ret = true;
       }
     }
-    // Add listener in case connection success.
-    if (ret) {
-      listeners_.push_back(listener);
+    // PointResult Port
+    if (listener->IsPointResultListening()) {
+      if (!IsPointListening()) {
+        ret = point_endpoint_->Connect();
+      } else {
+        ret = true;
+      }
     }
-    return ret;
   }
+  // Add listener in case connection success.
+  if (ret) {
+    listeners_.push_back(listener);
+  }
+  return ret;
+}
 
-  void Client::ClearListeners() {
-    listeners_.clear();
+void Client::ClearListeners() {
+  listeners_.clear();
 
+  output_endpoint_->Close(websocketpp::close::status::normal);
+  point_endpoint_->Close(websocketpp::close::status::normal);
+}
+
+void Client::UnsubscribeMessageListener(const std::shared_ptr<MessageListener>& listener) {
+  auto itr = std::find(listeners_.begin(), listeners_.end(), listener);
+  if (itr != listeners_.end()) {
+    listeners_.erase(itr);
+  }
+  // Close if no listener is listening OutputMessage.
+  if (std::none_of(listeners_.begin(),
+                   listeners_.end(),
+                   [](const std::shared_ptr<MessageListener>& listener) {
+                     return listener->IsOutputMessageListening();
+                   })) {
     output_endpoint_->Close(websocketpp::close::status::normal);
+  }
+  // Close if no listener is listening PointResult.
+  if (std::none_of(listeners_.begin(),
+                   listeners_.end(),
+                   [](const std::shared_ptr<MessageListener>& listener) {
+                     return listener->IsPointResultListening();
+                   })) {
     point_endpoint_->Close(websocketpp::close::status::normal);
   }
+}
 
-  void Client::UnsubscribeMessageListener(const std::shared_ptr<MessageListener>& listener) {
-    auto itr = std::find(listeners_.begin(), listeners_.end(), listener);
-    if (itr != listeners_.end()) {
-      listeners_.erase(itr);
-    }
-    // Close if no listener is listening OutputMessage.
-    if (std::none_of(listeners_.begin(),
-                    listeners_.end(),
-                    [](const std::shared_ptr<MessageListener>& listener) {
-                      return listener->IsOutputMessageListening();
-                    })) {
-      output_endpoint_->Close(websocketpp::close::status::normal);
-    }
-    // Close if no listener is listening PointResult.
-    if (std::none_of(listeners_.begin(),
-                    listeners_.end(),
-                    [](const std::shared_ptr<MessageListener>& listener) {
-                      return listener->IsPointResultListening();
-                    })) {
-      point_endpoint_->Close(websocketpp::close::status::normal);
-    }
+void Client::OnResultMessage(const std::string& message) {
+  sensr_proto::OutputMessage output;
+  if (!output.ParseFromString(message)) {
+    std::cerr << "Wrong format" << std::endl;
+    return;
   }
-
-  void Client::OnResultMessage(const std::string& message) {
-    sensr_proto::OutputMessage output;
-    if (!output.ParseFromString(message)) {
-      std::cerr << "Wrong format" << std::endl;
-      return;
-    }
-    bool is_output_buffer_overflow = false;
-    if (output.has_event() && output.event().has_health() &&
-        output.event().health().master() == sensr_proto::SystemHealth_Status_OUTPUT_BUFFER_OVERFLOW) {
-      is_output_buffer_overflow = true;
-    }
-    for (const auto& listener : listeners_) {
-      if (listener->IsOutputMessageListening()) {
-        listener->OnGetOutputMessage(output);
-        if (is_output_buffer_overflow) {
-          listener->OnError(MessageListener::Error::kOutputBufferOverflow, message);
-        }
+  bool is_output_buffer_overflow = false;
+  if (output.has_event() && output.event().has_health() &&
+      output.event().health().master() == sensr_proto::SystemHealth_Status_OUTPUT_BUFFER_OVERFLOW) {
+    is_output_buffer_overflow = true;
+  }
+  for (const auto& listener : listeners_) {
+    if (listener->IsOutputMessageListening()) {
+      listener->OnGetOutputMessage(output);
+      if (is_output_buffer_overflow) {
+        listener->OnError(MessageListener::Error::kOutputBufferOverflow, message);
       }
     }
   }
+}
 
-  bool Client::IsResultListening() const {
-    return std::any_of(
-        listeners_.begin(), listeners_.end(), [](const std::shared_ptr<MessageListener>& listener) {
-          return listener->IsOutputMessageListening();
-        });
+bool Client::IsResultListening() const {
+  return std::any_of(
+      listeners_.begin(), listeners_.end(), [](const std::shared_ptr<MessageListener>& listener) {
+        return listener->IsOutputMessageListening();
+      });
+}
+
+void Client::OnPointMessage(const std::string& message) {
+  sensr_proto::PointResult output;
+  if (!output.ParseFromString(message)) {
+    std::cerr << "Wrong format" << std::endl;
+    return;
   }
-
-  void Client::OnPointMessage(const std::string& message) {
-    sensr_proto::PointResult output;
-    if (!output.ParseFromString(message)) {
-      std::cerr << "Wrong format" << std::endl;
-      return;
-    }
-    for (const auto& listener : listeners_) {
-      if (listener->IsPointResultListening()) {
-        listener->OnGetPointResult(output);
-      }
-    }
-  }
-
-  void Client::OnResultError(const std::string& err) {
-    for (const auto& listener : listeners_) {
-      if (listener->IsOutputMessageListening()) {
-        listener->OnError(MessageListener::Error::kOutputMessageConnection, err);
-      }
+  for (const auto& listener : listeners_) {
+    if (listener->IsPointResultListening()) {
+      listener->OnGetPointResult(output);
     }
   }
+}
 
-  void Client::OnPointError(const std::string& err) {
-    for (const auto& listener : listeners_) {
-      if (listener->IsPointResultListening()) {
-        listener->OnError(MessageListener::Error::kPointResultConnection, err);
-      }
+void Client::OnResultError(const std::string& err) {
+  for (const auto& listener : listeners_) {
+    if (listener->IsOutputMessageListening()) {
+      listener->OnError(MessageListener::Error::kOutputMessageConnection, err);
     }
   }
+}
 
-  bool Client::IsPointListening() const {
-    return std::any_of(
-        listeners_.begin(), listeners_.end(), [](const std::shared_ptr<MessageListener>& listener) {
-          return listener->IsPointResultListening();
-        });
+void Client::OnPointError(const std::string& err) {
+  for (const auto& listener : listeners_) {
+    if (listener->IsPointResultListening()) {
+      listener->OnError(MessageListener::Error::kPointResultConnection, err);
+    }
   }
+}
+
+bool Client::IsPointListening() const {
+  return std::any_of(
+      listeners_.begin(), listeners_.end(), [](const std::shared_ptr<MessageListener>& listener) {
+        return listener->IsPointResultListening();
+      });
+}
 }  // namespace sensr

--- a/src/sensr_client.cpp
+++ b/src/sensr_client.cpp
@@ -8,7 +8,7 @@
 #include "websocket/websocket_secure_endpoint.h"
 
 namespace sensr {
-Client::Client(const std::string& address, const std::string& cert_path) : is_reconnecting_(false) {
+Client::Client(const std::string& address, const std::string& cert_path) {
   const uint16_t kOutputPort = 5050u;
   const uint16_t kPointPort = 5051u;
 
@@ -21,46 +21,45 @@ Client::Client(const std::string& address, const std::string& cert_path) : is_re
 Client::~Client() {
   ClearListeners();
 
-  io_context_.stop();
+  is_reconnecting_.store(false);
+
   if (reconnection_thread_.joinable()) {
     reconnection_thread_.join();
   }
 }
 
 void Client::Reconnect() {
-  if (!is_reconnecting_) {
-    if (reconnection_thread_.joinable()) {
-      reconnection_thread_.join();
+  if (is_reconnecting_) {
+    return;
+  }
+
+  if (reconnection_thread_.joinable()) {
+    reconnection_thread_.join();
+  }
+
+  is_reconnecting_ = true;
+
+  reconnection_thread_ = std::thread([this] {
+    size_t reconnection_counter = 0u;
+    while (is_reconnecting_) {
+      std::cout << "Reconnecting... " << ++reconnection_counter << "-th trial" << std::endl;
+      INFO_LOG("Reconnecting...");
+
+      for (const auto& broker : message_brokers_) {
+        broker->Reconnect();
+      }
+
+      if (std::all_of(message_brokers_.begin(), message_brokers_.end(), [](auto&& broker) {
+            return !broker->IsListening() || broker->IsConnected();
+          })) {
+        INFO_LOG("Reconnected!");
+        is_reconnecting_ = false;
+      } else {
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(100ms);
+      }
     }
-
-    is_reconnecting_ = true;
-    io_context_.restart();
-
-    asio::post(io_context_, [this]() { reconnection_async(); });
-    reconnection_thread_ = std::thread([this] { io_context_.run(); });
-  }
-}
-
-void Client::reconnection_async() {
-  INFO_LOG("Reconnecting...");
-  // auto temp = listeners_;
-
-  // ClearListeners();
-
-  // for (const auto& listener : temp) {
-  //   SubscribeMessageListener(listener);
-  // }
-  // const bool is_output_connected = !IsResultListening() || output_endpoint_->IsConnected();
-  // const bool is_point_connected = !IsPointListening() || point_endpoint_->IsConnected();
-
-  if (false) {
-    INFO_LOG("Reconnected!");
-    is_reconnecting_ = false;
-  } else {
-    asio::steady_timer sleep_timer(io_context_, asio::chrono::seconds(1));
-    sleep_timer.wait();
-    reconnection_async();
-  }
+  });
 }
 
 bool Client::SubscribeMessageListener(const std::shared_ptr<MessageListener>& listener) {

--- a/src/sensr_client.cpp
+++ b/src/sensr_client.cpp
@@ -2,34 +2,20 @@
 
 #include <algorithm>
 
+#include "message_broker.h"
 #include "sensr_message_listener.h"
 #include "websocket/websocket_endpoint.h"
 #include "websocket/websocket_secure_endpoint.h"
 
 namespace sensr {
-Client::Client(const std::string& address, const std::string& cert_path)
-    : is_reconnecting_(false) {
+Client::Client(const std::string& address, const std::string& cert_path) : is_reconnecting_(false) {
   const uint16_t kOutputPort = 5050u;
   const uint16_t kPointPort = 5051u;
 
-  // FIXME: this sucks
-  auto output_msg_cb = [this](auto&& msg) { OnResultMessage(msg); };
-  auto output_err_cb = [this](auto&& err) { OnResultError(err); };
-
-  auto point_msg_cb = [this](auto&& msg) { OnPointMessage(msg); };
-  auto point_err_cb = [this](auto&& err) { OnPointError(err); };
-
-  if (cert_path.empty()) {
-    output_endpoint_ =
-        std::make_unique<WebSocketEndPoint>(address, kOutputPort, output_msg_cb, output_err_cb);
-    point_endpoint_ =
-        std::make_unique<WebSocketEndPoint>(address, kPointPort, point_msg_cb, point_err_cb);
-  } else {
-    output_endpoint_ = std::make_unique<WebSocketSecureEndPoint>(
-        address, kOutputPort, output_msg_cb, output_err_cb, cert_path);
-    point_endpoint_ = std::make_unique<WebSocketSecureEndPoint>(
-        address, kPointPort, point_msg_cb, point_err_cb, cert_path);
-  }
+  message_brokers_[static_cast<uint32_t>(MessageType::Output)] =
+      std::make_unique<OutputMessageBroker>(address, kOutputPort, cert_path);
+  message_brokers_[static_cast<uint32_t>(MessageType::Points)] =
+      std::make_unique<PointMessageBroker>(address, kPointPort, cert_path);
 }
 
 Client::~Client() {
@@ -57,17 +43,17 @@ void Client::Reconnect() {
 
 void Client::reconnection_async() {
   INFO_LOG("Reconnecting...");
-  auto temp = listeners_;
+  // auto temp = listeners_;
 
-  ClearListeners();
+  // ClearListeners();
 
-  for (const auto& listener : temp) {
-    SubscribeMessageListener(listener);
-  }
-  const bool is_output_connected = !IsResultListening() || output_endpoint_->IsConnected();
-  const bool is_point_connected = !IsPointListening() || point_endpoint_->IsConnected();
+  // for (const auto& listener : temp) {
+  //   SubscribeMessageListener(listener);
+  // }
+  // const bool is_output_connected = !IsResultListening() || output_endpoint_->IsConnected();
+  // const bool is_point_connected = !IsPointListening() || point_endpoint_->IsConnected();
 
-  if (is_output_connected && is_point_connected) {
+  if (false) {
     INFO_LOG("Reconnected!");
     is_reconnecting_ = false;
   } else {
@@ -78,124 +64,23 @@ void Client::reconnection_async() {
 }
 
 bool Client::SubscribeMessageListener(const std::shared_ptr<MessageListener>& listener) {
-  bool ret = false;
-  // Connect to SENSR
-  if (std::find(listeners_.begin(), listeners_.end(), listener) == listeners_.end()) {
-    // OutputMessage Port
-    if (listener->IsOutputMessageListening()) {
-      if (!IsResultListening()) {
-        ret = output_endpoint_->Connect();
-      } else {
-        ret = true;
-      }
-    }
-    // PointResult Port
-    if (listener->IsPointResultListening()) {
-      if (!IsPointListening()) {
-        ret = point_endpoint_->Connect();
-      } else {
-        ret = true;
-      }
-    }
-  }
-  // Add listener in case connection success.
-  if (ret) {
-    listeners_.push_back(listener);
+  bool ret = true;
+  for (const auto& broker : message_brokers_) {
+    broker->TryAttachListener(listener);
+    ret = ret && (!broker->IsListening() || broker->IsConnected());
   }
   return ret;
 }
 
 void Client::ClearListeners() {
-  listeners_.clear();
-
-  output_endpoint_->Close(websocketpp::close::status::normal);
-  point_endpoint_->Close(websocketpp::close::status::normal);
+  for (const auto& broker : message_brokers_) {
+    broker->ClearListeners();
+  }
 }
 
 void Client::UnsubscribeMessageListener(const std::shared_ptr<MessageListener>& listener) {
-  auto itr = std::find(listeners_.begin(), listeners_.end(), listener);
-  if (itr != listeners_.end()) {
-    listeners_.erase(itr);
+  for (const auto& broker : message_brokers_) {
+    broker->TryDetachListener(listener);
   }
-  // Close if no listener is listening OutputMessage.
-  if (std::none_of(listeners_.begin(),
-                   listeners_.end(),
-                   [](const std::shared_ptr<MessageListener>& listener) {
-                     return listener->IsOutputMessageListening();
-                   })) {
-    output_endpoint_->Close(websocketpp::close::status::normal);
-  }
-  // Close if no listener is listening PointResult.
-  if (std::none_of(listeners_.begin(),
-                   listeners_.end(),
-                   [](const std::shared_ptr<MessageListener>& listener) {
-                     return listener->IsPointResultListening();
-                   })) {
-    point_endpoint_->Close(websocketpp::close::status::normal);
-  }
-}
-
-void Client::OnResultMessage(const std::string& message) {
-  sensr_proto::OutputMessage output;
-  if (!output.ParseFromString(message)) {
-    std::cerr << "Wrong format" << std::endl;
-    return;
-  }
-  bool is_output_buffer_overflow = false;
-  if (output.has_event() && output.event().has_health() &&
-      output.event().health().master() == sensr_proto::SystemHealth_Status_OUTPUT_BUFFER_OVERFLOW) {
-    is_output_buffer_overflow = true;
-  }
-  for (const auto& listener : listeners_) {
-    if (listener->IsOutputMessageListening()) {
-      listener->OnGetOutputMessage(output);
-      if (is_output_buffer_overflow) {
-        listener->OnError(MessageListener::Error::kOutputBufferOverflow, message);
-      }
-    }
-  }
-}
-
-bool Client::IsResultListening() const {
-  return std::any_of(
-      listeners_.begin(), listeners_.end(), [](const std::shared_ptr<MessageListener>& listener) {
-        return listener->IsOutputMessageListening();
-      });
-}
-
-void Client::OnPointMessage(const std::string& message) {
-  sensr_proto::PointResult output;
-  if (!output.ParseFromString(message)) {
-    std::cerr << "Wrong format" << std::endl;
-    return;
-  }
-  for (const auto& listener : listeners_) {
-    if (listener->IsPointResultListening()) {
-      listener->OnGetPointResult(output);
-    }
-  }
-}
-
-void Client::OnResultError(const std::string& err) {
-  for (const auto& listener : listeners_) {
-    if (listener->IsOutputMessageListening()) {
-      listener->OnError(MessageListener::Error::kOutputMessageConnection, err);
-    }
-  }
-}
-
-void Client::OnPointError(const std::string& err) {
-  for (const auto& listener : listeners_) {
-    if (listener->IsPointResultListening()) {
-      listener->OnError(MessageListener::Error::kPointResultConnection, err);
-    }
-  }
-}
-
-bool Client::IsPointListening() const {
-  return std::any_of(
-      listeners_.begin(), listeners_.end(), [](const std::shared_ptr<MessageListener>& listener) {
-        return listener->IsPointResultListening();
-      });
 }
 }  // namespace sensr

--- a/src/websocket/websocket_endpoint.cpp
+++ b/src/websocket/websocket_endpoint.cpp
@@ -1,56 +1,55 @@
 #include "./websocket_endpoint.h"
+
 #include "../logging.h"
 
-namespace sensr
-{   
-  WebSocketEndPoint::WebSocketEndPoint() : 
-    WebSocketEndPointBase()
-  {
-    Init(endpoint_);
-  }
+namespace sensr {
+WebSocketEndPoint::WebSocketEndPoint(const std::string& address,
+                                     uint16_t port,
+                                     WebSocketEndPointBase::MsgReceiver msg_cb,
+                                     WebSocketEndPointBase::ErrorReceiver err_cb)
+    : WebSocketEndPointBase(WebSocketEndPointBase::ConvertToUri(kProtocol, address, port),
+                            std::move(msg_cb),
+                            std::move(err_cb)) {
+  Init(endpoint_);
+}
 
-  WebSocketEndPoint::~WebSocketEndPoint() {
-    Fin(endpoint_);
-  }
+WebSocketEndPoint::~WebSocketEndPoint() { Fin(endpoint_); }
 
-  bool WebSocketEndPoint::Connect(const std::string &uri, 
-                 const WebSocketEndPointBase::MsgReceiver& func, 
-                 const WebSocketEndPointBase::ErrorReceiver& err_func) {
-    if (!connection_hdl_.expired()) {
-      INFO_LOG(uri + " is already connected.");
-      return true;
+bool WebSocketEndPoint::Connect() {
+  if (!connection_hdl_.expired()) {
+    INFO_LOG(uri + " is already connected.");
+    return true;
+  }
+  bool ret = false;
+  try {
+    std::error_code ec;
+    // Register our message handler
+    auto con = endpoint_.get_connection(kUri, ec);
+    if (ec) {
+      ERROR_LOG("> Connect initialization error: " + ec.message());
+      return false;
     }
-    bool ret = false;
-    try {
-      std::error_code ec;
-      // Register our message handler
-      auto con = endpoint_.get_connection(uri, ec);
-      if (ec) {
-        ERROR_LOG("> Connect initialization error: " + ec.message());
-        return false;
-      }
 
-      connection_hdl_ = con->get_handle();
+    connection_hdl_ = con->get_handle();
 
-      con->set_message_handler([this](websocketpp::connection_hdl hdl, websocketpp_client::message_ptr msg) {
-        OnMessage(msg->get_payload(), msg->get_opcode());
-      });
-      con->set_fail_handler([this](websocketpp::connection_hdl hdl) {
-        websocketpp_client::connection_ptr con = endpoint_.get_con_from_hdl(hdl);
-        OnFail(con->get_ec().message());
-      });
-      ret = Bind(con, func, err_func);
-      endpoint_.connect(con);
-    } catch(const std::exception& e) {
-      std::string error_msg = "> Failed to connect SENSR.";
-      error_msg += e.what();
-      ERROR_LOG(error_msg);
-      ret = false;
-    }
-    return ret;
+    con->set_message_handler(
+        [this](websocketpp::connection_hdl hdl, websocketpp_client::message_ptr msg) {
+          OnMessage(msg->get_payload(), msg->get_opcode());
+        });
+    con->set_fail_handler([this](websocketpp::connection_hdl hdl) {
+      websocketpp_client::connection_ptr con = endpoint_.get_con_from_hdl(hdl);
+      OnFail(con->get_ec().message());
+    });
+    ret = Bind(con);
+    endpoint_.connect(con);
+  } catch (const std::exception& e) {
+    std::string error_msg = "> Failed to connect SENSR.";
+    error_msg += e.what();
+    ERROR_LOG(error_msg);
+    ret = false;
   }
+  return ret;
+}
 
-  void WebSocketEndPoint::Close(websocketpp::close::status::value code) {
-    Unbind(endpoint_, code);
-  }
-} // namespace sensr
+void WebSocketEndPoint::Close(websocketpp::close::status::value code) { Unbind(endpoint_, code); }
+}  // namespace sensr

--- a/src/websocket/websocket_endpoint.cpp
+++ b/src/websocket/websocket_endpoint.cpp
@@ -3,13 +3,8 @@
 #include "../logging.h"
 
 namespace sensr {
-WebSocketEndPoint::WebSocketEndPoint(const std::string& address,
-                                     uint16_t port,
-                                     WebSocketEndPointBase::MsgReceiver msg_cb,
-                                     WebSocketEndPointBase::ErrorReceiver err_cb)
-    : WebSocketEndPointBase(WebSocketEndPointBase::ConvertToUri(kProtocol, address, port),
-                            std::move(msg_cb),
-                            std::move(err_cb)) {
+WebSocketEndPoint::WebSocketEndPoint(const std::string& address, uint16_t port)
+    : WebSocketEndPointBase(kProtocol, address, port) {
   Init(endpoint_);
 }
 

--- a/src/websocket/websocket_endpoint.h
+++ b/src/websocket/websocket_endpoint.h
@@ -9,10 +9,7 @@ class WebSocketEndPoint : public WebSocketEndPointBase {
   using websocketpp_client = websocketpp::client<websocketpp::config::asio_client>;
 
  public:
-  WebSocketEndPoint(const std::string& address,
-                    uint16_t port,
-                    WebSocketEndPointBase::MsgReceiver msg_cb,
-                    WebSocketEndPointBase::ErrorReceiver err_cb);
+  WebSocketEndPoint(const std::string& address, uint16_t port);
   ~WebSocketEndPoint() override;
 
   bool Connect() override;

--- a/src/websocket/websocket_endpoint.h
+++ b/src/websocket/websocket_endpoint.h
@@ -3,22 +3,24 @@
 #include "./websocket_endpoint_base.h"
 #include "websocketpp/config/asio_no_tls_client.hpp"
 #include "websocketpp/extensions/permessage_deflate/enabled.hpp"
-#include <functional>
-#include <thread>
-#include <memory>
-namespace sensr {
-  class WebSocketEndPoint : public WebSocketEndPointBase {
-  public:
-    using websocketpp_client = websocketpp::client<websocketpp::config::asio_client>;
-    WebSocketEndPoint();
-    ~WebSocketEndPoint() override;
 
-    bool Connect(const std::string &uri, 
-                 const WebSocketEndPointBase::MsgReceiver& func, 
-                 const WebSocketEndPointBase::ErrorReceiver& err_func) override;
-    void Close(websocketpp::close::status::value code) override;
-  
-  private:
-    websocketpp_client endpoint_;
-  };
-} // namespace sensr
+namespace sensr {
+class WebSocketEndPoint : public WebSocketEndPointBase {
+  using websocketpp_client = websocketpp::client<websocketpp::config::asio_client>;
+
+ public:
+  WebSocketEndPoint(const std::string& address,
+                    uint16_t port,
+                    WebSocketEndPointBase::MsgReceiver msg_cb,
+                    WebSocketEndPointBase::ErrorReceiver err_cb);
+  ~WebSocketEndPoint() override;
+
+  bool Connect() override;
+  void Close(websocketpp::close::status::value code) override;
+
+ private:
+  static constexpr const char* kProtocol = "ws";
+
+  websocketpp_client endpoint_;
+};
+}  // namespace sensr

--- a/src/websocket/websocket_endpoint_base.cpp
+++ b/src/websocket/websocket_endpoint_base.cpp
@@ -1,21 +1,32 @@
 #include "websocket_endpoint_base.h"
-#include <memory>
+
 namespace sensr {
-  WebSocketEndPointBase::WebSocketEndPointBase()
-  : status_(Status::kConnecting), msg_receiver_(), err_receiver_() {}
-  
-  void WebSocketEndPointBase::OnFail(const std::string& err_msg) {
-    status_ = Status::kFailed;
-    if (err_receiver_) {
-      err_receiver_(err_msg);
+WebSocketEndPointBase::WebSocketEndPointBase(std::string uri,
+                                             MsgReceiver msg_cb,
+                                             ErrorReceiver err_cb)
+    : kUri(std::move(uri)), msg_receiver_(std::move(msg_cb)), err_receiver_(std::move(err_cb)) {}
+
+std::string WebSocketEndPointBase::ConvertToUri(const std::string& protocol,
+                                                const std::string& address,
+                                                uint16_t port) {
+  std::stringstream ss;
+  ss << protocol << "://" << address << ":" << port;
+  return ss.str();
+}
+
+void WebSocketEndPointBase::OnFail(const std::string& err_msg) {
+  status_ = Status::kFailed;
+  if (err_receiver_) {
+    err_receiver_(err_msg);
+  }
+}
+
+void WebSocketEndPointBase::OnMessage(const std::string& msg,
+                                      websocketpp::frame::opcode::value opcode) {
+  if (status_ == Status::kOpen && opcode == websocketpp::frame::opcode::BINARY) {
+    if (msg_receiver_) {
+      msg_receiver_(msg);
     }
   }
-
-  void WebSocketEndPointBase::OnMessage(const std::string& msg, websocketpp::frame::opcode::value opcode) {
-    if (status_ == Status::kOpen && opcode == websocketpp::frame::opcode::BINARY) {
-      if (msg_receiver_) {
-        msg_receiver_(msg);
-      }
-    }     
-  } 
-} // namespace sensr
+}
+}  // namespace sensr

--- a/src/websocket/websocket_endpoint_base.cpp
+++ b/src/websocket/websocket_endpoint_base.cpp
@@ -1,10 +1,15 @@
 #include "websocket_endpoint_base.h"
 
 namespace sensr {
-WebSocketEndPointBase::WebSocketEndPointBase(std::string uri,
-                                             MsgReceiver msg_cb,
-                                             ErrorReceiver err_cb)
-    : kUri(std::move(uri)), msg_receiver_(std::move(msg_cb)), err_receiver_(std::move(err_cb)) {}
+WebSocketEndPointBase::WebSocketEndPointBase(const std::string& protocol,
+                                             const std::string& address,
+                                             uint16_t port)
+    : kUri(ConvertToUri(protocol, address, port)) {}
+
+void WebSocketEndPointBase::SetCallbacks(MsgReceiver msg_cb, ErrorReceiver err_cb) {
+  msg_receiver_ = std::move(msg_cb);
+  err_receiver_ = std::move(err_cb);
+}
 
 std::string WebSocketEndPointBase::ConvertToUri(const std::string& protocol,
                                                 const std::string& address,

--- a/src/websocket/websocket_endpoint_base.h
+++ b/src/websocket/websocket_endpoint_base.h
@@ -12,13 +12,14 @@ namespace sensr {
     using MsgReceiver = std::function<void(const std::string& msg)>;
     using ErrorReceiver = std::function<void(const std::string& err)>;
 
-    WebSocketEndPointBase(std::string uri, MsgReceiver msg_cb, ErrorReceiver err_cb);
-
+    WebSocketEndPointBase(const std::string& protocol, const std::string& address, uint16_t port);
     virtual ~WebSocketEndPointBase() = default;
 
     virtual bool Connect() = 0;
     virtual void Close(websocketpp::close::status::value code) = 0;
     bool IsConnected() const { return status_ == Status::kOpen; }
+
+    void SetCallbacks(MsgReceiver msg_cb, ErrorReceiver err_cb);
 
    protected:
     static std::string ConvertToUri(const std::string& protocol, const std::string& address, uint16_t port);

--- a/src/websocket/websocket_secure_endpoint.cpp
+++ b/src/websocket/websocket_secure_endpoint.cpp
@@ -1,84 +1,84 @@
 #include "./websocket_secure_endpoint.h"
-#include "../logging.h"
+
 #include <exception>
-	
-namespace sensr
-{   
-  WebSocketSecureEndPoint::WebSocketSecureEndPoint(const std::string& cert_path) : 
-    WebSocketEndPointBase(),
-    cert_path_(cert_path)
-  {
-    Init(endpoint_);
+
+#include "../logging.h"
+
+namespace sensr {
+WebSocketSecureEndPoint::WebSocketSecureEndPoint(const std::string& address,
+                                                 uint16_t port,
+                                                 WebSocketEndPointBase::MsgReceiver msg_cb,
+                                                 WebSocketEndPointBase::ErrorReceiver err_cb,
+                                                 const std::string& cert_path)
+    : WebSocketEndPointBase(WebSocketEndPointBase::ConvertToUri(kProtocol, address, port),
+                            std::move(msg_cb),
+                            std::move(err_cb)),
+      cert_path_(cert_path) {
+  Init(endpoint_);
+}
+
+WebSocketSecureEndPoint::~WebSocketSecureEndPoint() { Fin(endpoint_); }
+
+bool WebSocketSecureEndPoint::Connect() {
+  if (!connection_hdl_.expired()) {
+    INFO_LOG(uri + " is already connected.");
+    return true;
+  }
+  bool ret = false;
+  try {
+    if (!cert_path_.empty()) {
+      endpoint_.set_tls_init_handler(
+          std::bind(&WebSocketSecureEndPoint::OnTlsInit, this, std::placeholders::_1));
+    } else {
+      throw std::invalid_argument("> Certificate file path is empty.");
+    }
+    std::error_code ec;
+    // Register our message handler
+    auto con = endpoint_.get_connection(kUri, ec);
+    if (ec) {
+      ERROR_LOG("> WSS Connect initialization error: " + ec.message());
+      return false;
+    }
+
+    connection_hdl_ = con->get_handle();
+
+    con->set_message_handler(
+        [this](websocketpp::connection_hdl hdl, websocketpp_client::message_ptr msg) {
+          OnMessage(msg->get_payload(), msg->get_opcode());
+        });
+    con->set_fail_handler([this](websocketpp::connection_hdl hdl) {
+      websocketpp_client::connection_ptr con = endpoint_.get_con_from_hdl(hdl);
+      OnFail(con->get_ec().message());
+    });
+    ret = Bind(con);
+    endpoint_.connect(con);
+  } catch (const std::exception& e) {
+    std::string error_msg = "> Failed to connect SENSR.";
+    error_msg += e.what();
+    ERROR_LOG(error_msg);
+    ret = false;
   }
 
-  WebSocketSecureEndPoint::~WebSocketSecureEndPoint() {
-    Fin(endpoint_);
+  return ret;
+};
+
+void WebSocketSecureEndPoint::Close(websocketpp::close::status::value code) {
+  Unbind(endpoint_, code);
+}
+
+WebSocketSecureEndPoint::context_ptr WebSocketSecureEndPoint::OnTlsInit(
+    websocketpp::connection_hdl hdl) {
+  const auto ssl_method = websocketpp::lib::asio::ssl::context::sslv23;
+  context_ptr ctx = websocketpp::lib::make_shared<websocketpp::lib::asio::ssl::context>(ssl_method);
+
+  try {
+    ctx->set_options(websocketpp::lib::asio::ssl::context::default_workarounds | ssl_method);
+    ctx->set_verify_mode(websocketpp::lib::asio::ssl::verify_peer);
+    ctx->load_verify_file(cert_path_);
+  } catch (std::exception& e) {
+    ERROR_LOG(std::string("Error at TLS setup: ") + e.what());
+    ctx = nullptr;
   }
-
-  bool WebSocketSecureEndPoint::Connect(const std::string &uri,
-                 const WebSocketEndPointBase::MsgReceiver& func,
-                 const WebSocketEndPointBase::ErrorReceiver& err_func) {
-    
-    if (!connection_hdl_.expired()) {
-      INFO_LOG(uri + " is already connected.");
-      return true;
-    }
-    bool ret = false;
-    try {
-      if (!cert_path_.empty()) { 
-        endpoint_.set_tls_init_handler(std::bind(
-          &WebSocketSecureEndPoint::OnTlsInit,
-          this,
-          std::placeholders::_1));
-      } else {
-        throw std::invalid_argument("> Certificate file path is empty.");
-      }
-      std::error_code ec;
-      // Register our message handler
-      auto con = endpoint_.get_connection(uri, ec);
-      if (ec) {
-        ERROR_LOG("> WSS Connect initialization error: " + ec.message());
-        return false;
-      }
-      
-      connection_hdl_ = con->get_handle();
-
-      con->set_message_handler([this](websocketpp::connection_hdl hdl, websocketpp_client::message_ptr msg) {
-        OnMessage(msg->get_payload(), msg->get_opcode());
-      });
-      con->set_fail_handler([this](websocketpp::connection_hdl hdl) {
-        websocketpp_client::connection_ptr con = endpoint_.get_con_from_hdl(hdl);
-        OnFail(con->get_ec().message());
-      });
-      ret = Bind(con, func, err_func);
-      endpoint_.connect(con);
-    } catch(const std::exception& e) {
-      std::string error_msg = "> Failed to connect SENSR.";
-      error_msg += e.what();
-      ERROR_LOG(error_msg);
-      ret = false;
-    }
-
-    return ret;
-  };
-
-  void WebSocketSecureEndPoint::Close(websocketpp::close::status::value code) {
-    Unbind(endpoint_, code);
-  }  
-
-  WebSocketSecureEndPoint::context_ptr WebSocketSecureEndPoint::OnTlsInit(websocketpp::connection_hdl hdl) {
-    const auto ssl_method = websocketpp::lib::asio::ssl::context::sslv23;
-    context_ptr ctx = websocketpp::lib::make_shared<websocketpp::lib::asio::ssl::context>(ssl_method);
-
-    try {
-        ctx->set_options(websocketpp::lib::asio::ssl::context::default_workarounds |
-                         ssl_method);
-        ctx->set_verify_mode(websocketpp::lib::asio::ssl::verify_peer);
-        ctx->load_verify_file(cert_path_);
-    } catch (std::exception& e) {
-        ERROR_LOG(std::string("Error at TLS setup: ") + e.what());
-        ctx = nullptr;
-    }
-    return ctx;
-  } 
-} // namespace sensr
+  return ctx;
+}
+}  // namespace sensr

--- a/src/websocket/websocket_secure_endpoint.cpp
+++ b/src/websocket/websocket_secure_endpoint.cpp
@@ -7,13 +7,8 @@
 namespace sensr {
 WebSocketSecureEndPoint::WebSocketSecureEndPoint(const std::string& address,
                                                  uint16_t port,
-                                                 WebSocketEndPointBase::MsgReceiver msg_cb,
-                                                 WebSocketEndPointBase::ErrorReceiver err_cb,
                                                  const std::string& cert_path)
-    : WebSocketEndPointBase(WebSocketEndPointBase::ConvertToUri(kProtocol, address, port),
-                            std::move(msg_cb),
-                            std::move(err_cb)),
-      cert_path_(cert_path) {
+    : WebSocketEndPointBase(kProtocol, address, port), cert_path_(cert_path) {
   Init(endpoint_);
 }
 

--- a/src/websocket/websocket_secure_endpoint.h
+++ b/src/websocket/websocket_secure_endpoint.h
@@ -10,11 +10,7 @@ class WebSocketSecureEndPoint : public WebSocketEndPointBase {
   using context_ptr = websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context>;
 
  public:
-  WebSocketSecureEndPoint(const std::string& address,
-                          uint16_t port,
-                          WebSocketEndPointBase::MsgReceiver msg_cb,
-                          WebSocketEndPointBase::ErrorReceiver err_cb,
-                          const std::string& cert_path);
+  WebSocketSecureEndPoint(const std::string& address, uint16_t port, const std::string& cert_path);
   ~WebSocketSecureEndPoint() override;
 
   bool Connect() override;

--- a/src/websocket/websocket_secure_endpoint.h
+++ b/src/websocket/websocket_secure_endpoint.h
@@ -3,25 +3,31 @@
 #include "./websocket_endpoint_base.h"
 #include "websocketpp/config/asio_client.hpp"
 #include "websocketpp/extensions/permessage_deflate/enabled.hpp"
-#include <functional>
-#include <thread>
-#include <memory>
+
 namespace sensr {
-  class WebSocketSecureEndPoint : public WebSocketEndPointBase {
-  public:
-    using websocketpp_client = websocketpp::client<websocketpp::config::asio_tls_client>;
-    using context_ptr = websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context>;
-    WebSocketSecureEndPoint(const std::string& cert_path);
-    ~WebSocketSecureEndPoint() override;
+class WebSocketSecureEndPoint : public WebSocketEndPointBase {
+  using websocketpp_client = websocketpp::client<websocketpp::config::asio_tls_client>;
+  using context_ptr = websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context>;
 
-    bool Connect(const std::string &uri,
-                 const WebSocketEndPointBase::MsgReceiver& func,
-                 const WebSocketEndPointBase::ErrorReceiver& err_func) override;
-    void Close(websocketpp::close::status::value code) override;
+ public:
+  WebSocketSecureEndPoint(const std::string& address,
+                          uint16_t port,
+                          WebSocketEndPointBase::MsgReceiver msg_cb,
+                          WebSocketEndPointBase::ErrorReceiver err_cb,
+                          const std::string& cert_path);
+  ~WebSocketSecureEndPoint() override;
 
-  private:
-    context_ptr OnTlsInit(websocketpp::connection_hdl hdl);
-    websocketpp_client endpoint_;
-    const std::string cert_path_;
-  };
-} // namespace sensr
+  bool Connect() override;
+  void Close(websocketpp::close::status::value code) override;
+
+ private:
+  context_ptr OnTlsInit(websocketpp::connection_hdl hdl);
+
+ private:
+  static constexpr const char* kProtocol = "wss";
+
+  const std::string cert_path_;
+
+  websocketpp_client endpoint_;
+};
+}  // namespace sensr


### PR DESCRIPTION
### Proposal
The reconnection call stack keeps growing unbounded until it's reconnected to SENSR. This might be an issue with some hardware, so I've changed the logic to use a while loop in another thread instead of the tail recursion. 

Meanwhile, I have refactored the classes greatly to clear the ownership and responsibility of each class. 

### Change Summary
- revert async tail recursion back to the background while loop
- introduce MessageBroker to combine a WebSocket endpoint and its listeners
- minimize unnecessary linear search for a listener
- set callbacks only once and reuse them
- clear formatting (mostly indentation)