### PR TITLE
Added instructions to clone repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ sudo ldconfig
 
 ### Build SENSR SDK
 
+Download the repository using git clone
+
+```bash
+git clone https://github.com/seoulrobotics/sensr_sdk 
+```
+
 Update submodule:
 
 ```bash

--- a/python/README.md
+++ b/python/README.md
@@ -39,10 +39,10 @@ This Python SDK shows how to communicate with SENSR and parse the output in Pyth
     >
     > 1. If SENSR is running in the remote machine, replace `localhost` to other IP address or hostname accordingly.
     >
-    > 2. Replace `zone` to other value to print other types, one of: `zone`, `point`, `object`, `health`, `time`
+    > 2. Replace `object` to other value to print other types, one of: `zone`, `point`, `object`, `health`, `time`
 
     ```bash
-    python3 ./console_output.py --address localhost --example_type zone
+    python3 ./console_output.py --address localhost --example_type object
     ```
 
 ## Running examples


### PR DESCRIPTION
1. Added a line informing users that they should clone the repository and not download it in any other way.
2. Changed the python console output command in the readme from zone data to object data. This is because our sample file has objects but no zones. If the user runs it with zones they may not get any output.