### PR TITLE
fixed output_stream bug

### DIFF
--- a/python/sensr_message_listener.py
+++ b/python/sensr_message_listener.py
@@ -81,7 +81,8 @@ class MessageListener(metaclass=ABCMeta):
                             pass
                         except websockets.ConnectionClosedError:
                             self._on_error("Closed by error.")
-            except:
+            except OSError:
+                print('Failed to connect to SENSR, attempting reconnect...')
                 time.sleep(1)
 
     async def _point_stream(self):


### PR DESCRIPTION
Pre-fix:
https://github.com/seoulrobotics/sensr_sdk/assets/45466948/f69a65f7-28b1-458f-a6fa-ada0032c7849

Post-fix
https://github.com/seoulrobotics/sensr_sdk/assets/45466948/dc0565bc-f43a-44cd-81c2-871abb47a291

As shown in the pre-fix video, when SENSR shuts down while the SDK is running, an exception occurs and `console_output.py` crashes. On restarting SENSR the SDK is not able to re-establish the connection.

The cause of this bug can be found inside the `sensr_message_listener.py` file, which is used by `console_output.py`. Specifically, the bug seems to occur on line 65 inside the `_output_stream` method. The code crashes because, when SENSR shuts down, the `websockets.connect` method fails to connect and raises an exception.

The proposed fix to circumvent the crash is to wrap the connect method and its corresponding body in a try-except block, adding a sleeping timer inside the except block to avoid excessive reconnection attempts. In this case, instead of raising an exception and crashing, if the connect method fails, a 1-second sleeping timer will be initiated, after which the program will try to reconnect.