### PR TITLE
fix measuring time delta for javascript sdk

### DIFF
--- a/javascript/javascript_sdk/src/get_data.js
+++ b/javascript/javascript_sdk/src/get_data.js
@@ -38,7 +38,7 @@ const get_point_data = (client) => {
       }
   });
 }
-  
+
 const get_object_data = (client) => {
   client.listenToObjectUpdate(response => {
     const objects = response.getObjectsList();
@@ -109,11 +109,17 @@ const get_health_data = (client) => {
     }
   });
 }
-  
+
+function convertTimestampToMillis(timestamp) {
+  const seconds = timestamp.getSeconds();
+  const nanos = timestamp.getNanos();
+  return (seconds * 1000) + Math.floor((nanos / 1000000));
+}
+
 const get_time_data = (client) => {
-    client.listenToObjectUpdate(null, null, response => { 
+  client.listenToObjectUpdate(null, null, response => { 
       let cur_time = new Date();
-      console.log('Diff: %f ms', cur_time.getTime()- (response.array[0]*1000));
+      console.log('Diff: %f ms', cur_time.getTime()- convertTimestampToMillis(response));
     });
 }
 

--- a/javascript/javascript_sdk/src/get_data.js
+++ b/javascript/javascript_sdk/src/get_data.js
@@ -118,9 +118,9 @@ function convertTimestampToMillis(timestamp) {
 
 const get_time_data = (client) => {
   client.listenToObjectUpdate(null, null, response => { 
-      let cur_time = new Date();
-      console.log('Diff: %f ms', cur_time.getTime()- convertTimestampToMillis(response));
-    });
+    let cur_time = new Date();
+    console.log('Diff: %f ms', cur_time.getTime()- convertTimestampToMillis(response));
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
* the javascript sdk was only considering seconds of the received result for calculating the latency
* the timestamp of the result is divided into seconds and nanos (two ints)
* this fix considers also the nanoseconds